### PR TITLE
test: fix InMemoryFileTest#file_with_only_text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ application-*.properties
 !application-test.properties
 .env
 target/
-mockstorage/
+mock_storage/
 .DS_Store
 static-front/
 logs/
@@ -43,4 +43,3 @@ tmp
 
 # Used in test
 7fdad8b1*
-

--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ Create a new folder `mock_storage` to store files.
 Create the file `application-dev.properties` in `dossierfacile-bo/src/main/resources`
 
 ```properties
-mock.storage.path=/path/to/mock_storage/
 server.port=8081
 application.name=bo
 application.domain=http://localhost:8081
 domain.protocol=http
 environment=localhost
 
-mock.storage.path=mockstorage
 storage.provider.list=LOCAL
+mock.storage.path=mock_storage
 
 # SQL
 spring.datasource.url=jdbc:postgresql://localhost:5432/dossierfacile
@@ -82,7 +81,7 @@ brevo.apikey=
 Create the file `application-dev.properties` in `dossierfacile-api-tenant/src/main/resources`
 
 ```properties
-mock.storage.path=/path/to/mock_storage/
+mock.storage.path=mock_storage
 storage.provider.list=LOCAL
 api.version=3
 tenant.base.url=localhost:9002
@@ -106,7 +105,7 @@ brevo.apikey=
 Create the file `application-dev.properties` in `dossierfacile-api-owner/src/main/resources`
 
 ```properties
-mock.storage.path=/path/to/mock_storage/
+mock.storage.path=mock_storage
 owner.url=http://localhost:3000
 server.port=8083
 # SQL
@@ -129,7 +128,7 @@ brevo.apikey=
 Create the file `application-dev.properties` in `dossierfacile-process-file/src/main/resources`
 
 ```properties
-mock.storage.path=/path/to/mock_storage/
+mock.storage.path=mock_storage
 storage.provider.list=LOCAL
 server.port=8088
 # SQL
@@ -149,7 +148,7 @@ Create the file `application-dev.properties` in `dossierfacile-api-watermark/src
 
 ```properties
 server.port=8091
-mock.storage.path=/path/to/mock_storage/
+mock.storage.path=mock_storage
 storage.provider.list=LOCAL
 # SQL
 spring.datasource.url=jdbc:postgresql://localhost:5433/dossierfacile
@@ -160,7 +159,7 @@ spring.datasource.password=
 Create the file `application-dev.properties` in `dossierfacile-pdf-generator/src/main/resources`
 
 ```properties
-mock.storage.path=/path/to/mock_storage/
+mock.storage.path=mock_storage
 storage.provider.list=LOCAL
 # SQL
 spring.datasource.url= jdbc:postgresql://localhost:5433/dossierfacile

--- a/dossierfacile-process-file/src/test/java/fr/dossierfacile/process/file/util/InMemoryFileTest.java
+++ b/dossierfacile-process-file/src/test/java/fr/dossierfacile/process/file/util/InMemoryFileTest.java
@@ -52,13 +52,8 @@ class InMemoryFileTest {
 
         assertThat(inMemoryPdfFile.hasQrCode()).isFalse();
         assertThat(inMemoryPdfFile.has2DDoc()).isFalse();
-        assertThat(inMemoryPdfFile.getContentAsString()).isEqualTo("""
-
-
-                Test document
-
-
-                """);
+        assertThat(inMemoryPdfFile.getContentAsString()).isNotEmpty();
+        assertThat(inMemoryPdfFile.getContentAsString().trim()).isEqualTo("Test document");
     }
 
     private FileStorageService classpathStorageService() throws IOException {


### PR DESCRIPTION
InMemoryFileTest#file_with_only_text failed due to a missing space between the expected result and the current result.

Using trim on the current result, as trimming whitespaces is not significant when parsing text-only PDF files.

I also updated .gitignore file to match "mock_storage" folder name with name suggested in README.