### PR TITLE
🐛 Fix(owner): don't count archived applications

### DIFF
--- a/dossierfacile-api-owner/src/main/java/fr/dossierfacile/api/dossierfacileapiowner/user/OwnerMapper.java
+++ b/dossierfacile-api-owner/src/main/java/fr/dossierfacile/api/dossierfacileapiowner/user/OwnerMapper.java
@@ -5,8 +5,11 @@ import fr.dossierfacile.api.dossierfacileapiowner.property.LightPropertyModel;
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Owner;
 import fr.dossierfacile.common.entity.Property;
+import fr.dossierfacile.common.enums.TenantFileStatus;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,7 +23,15 @@ public abstract class OwnerMapper {
     @Mapping( target="totalGuarantorSalary", expression="java(apartmentSharing.totalGuarantorSalary())" )
     public abstract ApartmentSharingModel apartmentSharingToApartmentSharingModel(ApartmentSharing apartmentSharing);
 
-    @Mapping( target="propertyApartmentSharingCount", expression="java(property.getPropertiesApartmentSharing().size())" )
-    @Mapping( source="dpeDate", target="dpeDate", dateFormat="yyyy-MM-dd")
+    @Mapping( source="property", target="propertyApartmentSharingCount", qualifiedByName="validApplicationsCount" )
+    @Mapping( source="dpeDate", target="dpeDate", dateFormat="yyyy-MM-dd" )
     public abstract LightPropertyModel toLightPropertyModel(Property property);
+
+    @Named("validApplicationsCount")
+    public static int getValidApplicationsCount(Property property) {
+        long count = property.getPropertiesApartmentSharing().stream()
+            .filter(p -> !p.getApartmentSharing().getStatus().equals(TenantFileStatus.ARCHIVED))
+            .count();
+        return (int) count;
+    }
 }


### PR DESCRIPTION
In dashboard, the application number was counting all applications, including the archived ones. Whereas in the consult property page, only non-archived applications were listed.