### PR TITLE
fix: 🐛 Avoid automatic response when there is existing Response

### DIFF
--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/log/GlobalExceptionHandler.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/log/GlobalExceptionHandler.java
@@ -1,17 +1,22 @@
 package fr.dossierfacile.api.front.log;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(Exception e) {
+    public ResponseEntity<String> handleException(Exception e) throws Exception {
+        if (AnnotationUtils.findAnnotation(e.getClass(), ResponseStatus.class) != null) {
+            throw e;
+        }
         log.error("Unhandled exception: ", e);
         return new ResponseEntity<>("Internal Server Error", HttpStatus.INTERNAL_SERVER_ERROR);
     }


### PR DESCRIPTION
Automatically log Exceptions that were not handled with right ResponseStatus