### PR TITLE
hotfix(api-tenant): add logs to brevo ApiException to debug

### DIFF
--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/MailServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/MailServiceImpl.java
@@ -293,7 +293,12 @@ public class MailServiceImpl implements MailService {
         try {
             apiInstance.sendTransacEmail(sendSmtpEmail);
         } catch (ApiException e) {
-            log.error("Email Api Exception", e);
+            log.error("Error with brevo send mail – code={} , headers={} , body={}, message={}",
+                    e.getCode(),
+                    e.getResponseHeaders(),
+                    e.getResponseBody(),
+                    e.getMessage(),
+                    e);
             throw new InternalError("Mail cannot be send - try later");
         }
     }


### PR DESCRIPTION
We have a lot of fails on this route : /api/tenant/sendFileByMail When we inspect inside the logs, brevo return an error some times. So we need to log the api exception to understand what happen