### PR TITLE
fix: change 2ddoc signature validation wording to make it less confusing

### DIFF
--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/dto/DisplayableBarCodeFileAnalysis.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/dto/DisplayableBarCodeFileAnalysis.java
@@ -52,15 +52,15 @@ public class DisplayableBarCodeFileAnalysis {
     }
 
     public String getAuthenticationStatusCssClass() {
-        return analysis.getAuthenticationStatus() == VALID ? "fa-check text-success" : "fa-times text-danger";
+        return analysis.getAuthenticationStatus() == VALID ? "fa-info text-info" : "fa-times text-danger";
     }
 
     public String getAuthenticationStatus() {
         return switch (analysis.getAuthenticationStatus()) {
-            case VALID -> "Authentifié";
-            case INVALID -> analysis.getBarCodeType() == TWO_D_DOC ? "Falsifié" : "Non authentifié";
-            case API_ERROR -> "Impossible de vérifier l'authenticité auprès de l'émetteur";
-            case ERROR -> "Erreur lors de l'authentification";
+            case VALID -> "2D-Doc lu";
+            case INVALID -> analysis.getBarCodeType() == TWO_D_DOC ? "2D-Doc falsifié" : "2D-Doc non lu";
+            case API_ERROR -> "Impossible de vérifier la signature du 2D-Doc";
+            case ERROR -> "Erreur lors de la lecture du 2D-Doc";
         };
     }
 

--- a/dossierfacile-bo/src/main/resources/static/css/apartment-sharing-view.css
+++ b/dossierfacile-bo/src/main/resources/static/css/apartment-sharing-view.css
@@ -1,0 +1,11 @@
+.prevalidation-background-DENIED{
+    background-color: var(--bs-danger-bg-subtle);
+}
+.prevalidation-background-UNDEFINED{
+    background-color: #f0d39c;
+    color: #929292;
+}
+.prevalidation-background-CHECKED{
+    background-color: #e1f2e4;
+    color: #929292;
+}

--- a/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
@@ -6,6 +6,7 @@
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4">
 <head>
     <title>DossierFacile</title>
+    <link rel="stylesheet" href="/css/apartment-sharing-view.css"/>
 </head>
 <body>
 <div layout:fragment="content" th:remove="tag">
@@ -736,7 +737,8 @@
                                             </span>
                                         </li>
                                     </ul>
-                                    <div th:if="${document.getDocumentAnalysisReport()!=null}">
+                                    <div th:if="${document.getDocumentAnalysisReport()!=null}"
+                                         th:class="${'prevalidation-background-' + document.getDocumentAnalysisReport().getAnalysisStatus() }">
                                         <hr/>
                                         Statut de la vérification automatique:
                                         <span th:text="${document.getDocumentAnalysisReport().getAnalysisStatus}"></span>
@@ -953,7 +955,8 @@
                                             </span>
                                         </li>
                                     </ul>
-                                    <div th:if="${document.getDocumentAnalysisReport()!=null}">
+                                    <div th:if="${document.getDocumentAnalysisReport()!=null}"
+                                         th:class="${'prevalidation-background-' + document.getDocumentAnalysisReport().getAnalysisStatus() }">
                                         <hr/>
                                         Statut de la vérification automatique:
                                         <span th:text="${document.getDocumentAnalysisReport().getAnalysisStatus}"></span>


### PR DESCRIPTION
Proposition :
- Remplacer le terme “Authentifié” par “2D-Doc lu”
- Changer la couleur verte et l’icone ✔️ par la couleur bleu et l’icone ℹ️
- Mettre en avant le statut de la vérification automatique dans la page “apartment_sharing_view”