### PR TITLE
feat(document-analysis): improve tax name rule

### DIFF
--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
@@ -155,6 +155,8 @@ public class TaxNamesRule extends BaseTaxRule {
         List<String> firstNamesToMatch = documentIdentity.getFirstNames().stream()
                 .map(this::normalize)
                 .filter(name -> !name.isBlank())
+                .flatMap(name -> Stream.of(name, name.replaceAll("[-'_]", " ")))
+                .flatMap(this::splitTokens)
                 .distinct()
                 .toList();
 
@@ -169,11 +171,30 @@ public class TaxNamesRule extends BaseTaxRule {
         List<String> lastNamesToMatch = Stream.of(documentIdentity.getLastName(), documentIdentity.getPreferredName())
                 .map(this::normalize)
                 .filter(name -> !name.isBlank())
-                .flatMap(name -> Stream.of(name, name.replaceAll("[-'_]", " ")))
+                .flatMap(this::lastNameVariants)
                 .distinct()
                 .toList();
 
         return hasIdentityMatch(barcodeIdentities, lastNamesToMatch, true);
+    }
+
+    private Stream<String> lastNameVariants(String normalizedName) {
+        Stream<String> baseVariants = Stream.of(
+                normalizedName,
+                normalizedName.replaceAll("[-'_]", " ")
+        );
+
+        Stream<String> composedVariant = Stream.empty();
+        List<String> tokens = splitTokens(normalizedName).toList();
+        
+        if (tokens.size() >= 2 ) { // normalizedName is composed
+            // filter out short last names otherwise rule is too permissive
+            composedVariant = tokens.stream()
+                .filter(token -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
+                .map(token -> token.replaceAll("[-'_]", ""));
+        }
+
+        return Stream.concat(baseVariants, composedVariant);
     }
 
     private boolean hasIdentityMatch(List<String> barcodeIdentities, List<String> expectedTokens, boolean strictOnWholeIdentity) {

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
@@ -191,7 +191,7 @@ public class TaxNamesRule extends BaseTaxRule {
             // filter out short last names otherwise rule is too permissive
             composedVariant = tokens.stream()
                 .filter(token -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
-                .map(token -> token.replaceAll("[-'_]", ""));
+                .map(token -> token.replaceAll("[-'_]", " "));
         }
 
         return Stream.concat(baseVariants, composedVariant);

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRuleTest.java
@@ -150,9 +150,9 @@ class TaxNamesRuleTest {
                         RuleValidatorOutput.RuleLevel.PASSED
                 ),
                 Arguments.of(
-                        "Should failed when short last names",
-                        tenant("XU", "de jean"),
-                        List.of(fakeAvisImposition("de jean")),
+                        "Should failed when only first name is present",
+                        tenant("XU", "De Jean"),
+                        List.of(fakeAvisImposition("De Jean")),
                         RuleValidatorOutput.RuleLevel.FAILED
                 ),
                 Arguments.of(

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRuleTest.java
@@ -151,14 +151,26 @@ class TaxNamesRuleTest {
                 ),
                 Arguments.of(
                         "Should failed when short last names",
-                        tenant("XU", "jean"),
+                        tenant("XU", "de jean"),
                         List.of(fakeAvisImposition("de jean")),
                         RuleValidatorOutput.RuleLevel.FAILED
                 ),
                 Arguments.of(
-                        "Should failed composed names from tenant",
-                        tenant("SMITH DOE", "jean"),
-                        List.of(fakeAvisImposition("Smith jean")),
+                        "Should passed with exact short last names",
+                        tenant("XU YI", "Jean"),
+                        List.of(fakeAvisImposition("XU YI Jean")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should failed when short last names, otherwise rule is too permissive",
+                        tenant("XU YI", "Jean"),
+                        List.of(fakeAvisImposition("YI Jean")),
+                        RuleValidatorOutput.RuleLevel.FAILED
+                ),
+                Arguments.of(
+                        "Should failed short composed names, otherwise rule is too permissive",
+                        tenant("SMITH DOE", "Jean"),
+                        List.of(fakeAvisImposition("DOE Jean")),
                         RuleValidatorOutput.RuleLevel.FAILED
                 ),
                 Arguments.of(
@@ -183,6 +195,42 @@ class TaxNamesRuleTest {
                         "Should passed",
                         tenant("SMITH-DOE", "A"),
                         List.of(fakeAvisImposition("SMITH-DOE A")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with hyphenated first names and second declarant mismatch",
+                        tenant("Dubois", "Pierre-Paul"),
+                        List.of(fakeAvisImposition("DUBOIS PIERRE PAUL", "DUBOIS MARIE CLAIRE")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with multiple first names and hyphen",
+                        tenant("DIAKITE", "Amadou-Oumar Diallo"),
+                        List.of(fakeAvisImposition("DIAKITE AMADOU OUMAR")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with composed tenant last name and partial barcode last name",
+                        tenant("GONZALEZ RODRIGUEZ", "Carlos Manuel"),
+                        List.of(fakeAvisImposition("GONZALEZ CARLOS")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with accent normalization in first name",
+                        tenant("Fontaine", "Marie-Cécile"),
+                        List.of(fakeAvisImposition("FONTAINE LUCAS", "FONTAINE MARIE CECILE")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with hyphenated tenant identity normalized as spaces",
+                        tenant("Dubois-Rivière", "Thomas-Antoine"),
+                        List.of(fakeAvisImposition("DUBOIS RIVIERE THOMAS ANTOINE", "LEFEVRE CAMILLE")),
+                        RuleValidatorOutput.RuleLevel.PASSED
+                ),
+                Arguments.of(
+                        "Should pass with apostrophe and multiple composed last names",
+                        tenant("OMAR D'SOU KONATE", "Aïcha"),
+                        List.of(fakeAvisImposition("DSOU AICHA")),
                         RuleValidatorOutput.RuleLevel.PASSED
                 )
         );


### PR DESCRIPTION
- Le problème identifié sur les noms composés existent également avec les prénoms composés !
    - Identité 2DDOC : `DUPONT ANNE LAURE`
    - Identité Dossier (prénom) : `Anne-Laure`
    - La règle `R_TAX_NAMES` échoue !
- Double nom de famille côté DossierFacile, simple nom côté 2DDOC
    - Identité 2DDOC : `DUPONT ANNE LAURE`
    - Identité Dossier (nom) : `MARTIN DUPONT` 
    - La règle `R_TAX_NAMES` échoue !