### PR TITLE
fix(bo): harmonize display in BO when tenant or garantor have no tax to show

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ zxing-cpp/data/zxing-cpp
 # Used in test
 7fdad8b1*
 
+# AI tools
+/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,3 @@ zxing-cpp/data/zxing-cpp
 
 # Used in test
 7fdad8b1*
-
-# AI tools
-/CLAUDE.md

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/register/guarantor/natural_person/DocumentTaxGuarantorNaturalPerson.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/register/guarantor/natural_person/DocumentTaxGuarantorNaturalPerson.java
@@ -63,7 +63,7 @@ public class DocumentTaxGuarantorNaturalPerson extends AbstractDocumentSaveStep<
         if (documentTaxGuarantorNaturalPersonForm.getAvisDetected() != null) {
             document.setAvisDetected(documentTaxGuarantorNaturalPersonForm.getAvisDetected());
         }
-        if (documentSubCategory == OTHER_TAX && documentTaxGuarantorNaturalPersonForm.getNoDocument()) {
+        if (documentSubCategory == OTHER_TAX) {
             document.setCustomText(documentTaxGuarantorNaturalPersonForm.getCustomText());
         }
         documentRepository.save(document);

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/register/DocumentTaxCustomTextTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/register/DocumentTaxCustomTextTest.java
@@ -1,0 +1,173 @@
+package fr.dossierfacile.api.front.register;
+
+import fr.dossierfacile.api.front.register.form.guarantor.natural_person.DocumentTaxGuarantorNaturalPersonForm;
+import fr.dossierfacile.api.front.register.form.tenant.DocumentTaxForm;
+import fr.dossierfacile.api.front.register.guarantor.natural_person.DocumentTaxGuarantorNaturalPerson;
+import fr.dossierfacile.api.front.register.tenant.DocumentTax;
+import fr.dossierfacile.api.front.repository.DocumentRepository;
+import fr.dossierfacile.api.front.repository.GuarantorRepository;
+import fr.dossierfacile.api.front.service.interfaces.ApartmentSharingService;
+import fr.dossierfacile.api.front.service.interfaces.DocumentService;
+import fr.dossierfacile.api.front.service.interfaces.TenantStatusService;
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.Guarantor;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.ApplicationType;
+import fr.dossierfacile.common.enums.DocumentCategory;
+import fr.dossierfacile.common.enums.DocumentSubCategory;
+import fr.dossierfacile.common.enums.TypeGuarantor;
+import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.DocumentHelperService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ * This test demonstrates inconsistency between tenant and guarantor handling of customText
+ * for OTHER_TAX documents when noDocument=false (i.e. files are provided).
+ * How to reproduce in frontend: "Pas d'avis d'imposition" > "Autre Situation"
+ * Tenant: saves customText regardless of noDocument flag.
+ * Guarantor: only saves customText when noDocument=true — loses it when files are present.
+ */
+@ExtendWith(MockitoExtension.class)
+class DocumentTaxCustomTextTest {
+
+    private static final String EXPLANATION = "J'ai vécu à l'étranger et je n'ai pas d'avis d'imposition français.";
+
+    private static Document invokeSaveDocument(Object service, Tenant tenant, Object form) throws Exception {
+        Method method = service.getClass().getDeclaredMethod("saveDocument", Tenant.class, form.getClass());
+        method.setAccessible(true);
+        return (Document) method.invoke(service, tenant, form);
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class TenantTax {
+
+        @Mock
+        DocumentHelperService documentHelperService;
+        @Mock
+        TenantCommonRepository tenantRepository;
+        @Mock
+        DocumentRepository documentRepository;
+        @Mock
+        DocumentService documentService;
+        @Mock
+        TenantStatusService tenantStatusService;
+        @Mock
+        ApartmentSharingService apartmentSharingService;
+
+        @InjectMocks
+        DocumentTax documentTax;
+
+        private Tenant tenant;
+
+        @BeforeEach
+        void setUp() {
+            var apartmentSharing = ApartmentSharing.builder().id(1L).applicationType(ApplicationType.ALONE).build();
+            tenant = Tenant.builder().id(1L).apartmentSharing(apartmentSharing).documents(new ArrayList<>()).build();
+            apartmentSharing.setTenants(new ArrayList<>());
+
+            when(documentRepository.findFirstByDocumentCategoryAndTenant(eq(DocumentCategory.TAX), any()))
+                    .thenReturn(Optional.empty());
+            when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(tenantRepository.save(any())).thenReturn(tenant);
+        }
+
+        @Test
+        void shouldSaveCustomTextForOtherTaxWithFiles() throws Exception {
+            var form = new DocumentTaxForm();
+            form.setTypeDocumentTax(DocumentSubCategory.OTHER_TAX);
+            form.setNoDocument(false);
+            form.setCustomText(EXPLANATION);
+            form.setDocuments(Collections.emptyList());
+
+            var captor = ArgumentCaptor.forClass(Document.class);
+            when(documentRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            invokeSaveDocument(documentTax, tenant, form);
+
+            Document saved = captor.getValue();
+            assertThat(saved.getCustomText()).isEqualTo(EXPLANATION);
+            assertThat(saved.getNoDocument()).isFalse();
+        }
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class GuarantorTax {
+
+        @Mock
+        DocumentHelperService documentHelperService;
+        @Mock
+        TenantCommonRepository tenantRepository;
+        @Mock
+        DocumentRepository documentRepository;
+        @Mock
+        GuarantorRepository guarantorRepository;
+        @Mock
+        DocumentService documentService;
+        @Mock
+        TenantStatusService tenantStatusService;
+        @Mock
+        ApartmentSharingService apartmentSharingService;
+
+        @InjectMocks
+        DocumentTaxGuarantorNaturalPerson documentTaxGuarantor;
+
+        private Tenant tenant;
+
+        @BeforeEach
+        void setUp() {
+            var apartmentSharing = ApartmentSharing.builder().id(1L).applicationType(ApplicationType.ALONE).build();
+            tenant = Tenant.builder().id(1L).apartmentSharing(apartmentSharing).documents(new ArrayList<>()).build();
+            apartmentSharing.setTenants(new ArrayList<>());
+
+            var guarantor = Guarantor.builder().id(10L).tenant(tenant).typeGuarantor(TypeGuarantor.NATURAL_PERSON).documents(new ArrayList<>()).build();
+
+            when(guarantorRepository.findByTenantAndTypeGuarantorAndId(any(), eq(TypeGuarantor.NATURAL_PERSON), eq(10L)))
+                    .thenReturn(Optional.of(guarantor));
+            when(documentRepository.findFirstByDocumentCategoryAndGuarantor(eq(DocumentCategory.TAX), any()))
+                    .thenReturn(Optional.empty());
+            when(documentRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+            when(tenantRepository.save(any())).thenReturn(tenant);
+        }
+
+        @Test
+        void shouldSaveCustomTextForOtherTaxWithFiles() throws Exception {
+            var form = new DocumentTaxGuarantorNaturalPersonForm();
+            form.setTypeDocumentTax(DocumentSubCategory.OTHER_TAX);
+            form.setNoDocument(false);
+            form.setCustomText(EXPLANATION);
+            form.setGuarantorId(10L);
+            form.setDocuments(Collections.emptyList());
+
+            var captor = ArgumentCaptor.forClass(Document.class);
+            when(documentRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+            invokeSaveDocument(documentTaxGuarantor, tenant, form);
+
+            Document saved = captor.getValue();
+            // guarantor loses customText when noDocument=false, unlike tenant
+            assertThat(saved.getCustomText()).isNull();
+            assertThat(saved.getNoDocument()).isFalse();
+        }
+    }
+}

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/register/DocumentTaxCustomTextTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/register/DocumentTaxCustomTextTest.java
@@ -40,11 +40,9 @@ import static org.mockito.Mockito.when;
 
 /**
  *
- * This test demonstrates inconsistency between tenant and guarantor handling of customText
- * for OTHER_TAX documents when noDocument=false (i.e. files are provided).
- * How to reproduce in frontend: "Pas d'avis d'imposition" > "Autre Situation"
- * Tenant: saves customText regardless of noDocument flag.
- * Guarantor: only saves customText when noDocument=true — loses it when files are present.
+ * Ensures tenant and guarantor both persist customText for OTHER_TAX documents
+ * when noDocument=false (i.e. files are provided).
+ * How to reproduce in frontend: "Pas d'avis d'imposition" > "Autre Situation".
  */
 @ExtendWith(MockitoExtension.class)
 class DocumentTaxCustomTextTest {
@@ -165,8 +163,7 @@ class DocumentTaxCustomTextTest {
             invokeSaveDocument(documentTaxGuarantor, tenant, form);
 
             Document saved = captor.getValue();
-            // guarantor loses customText when noDocument=false, unlike tenant
-            assertThat(saved.getCustomText()).isNull();
+            assertThat(saved.getCustomText()).isEqualTo(EXPLANATION);
             assertThat(saved.getNoDocument()).isFalse();
         }
     }

--- a/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
@@ -954,7 +954,7 @@
                                     <div th:if="${document.getMonthlySum()!=null}">
                                         <span th:text="${'Montly sum: '+document.getMonthlySum()}"></span>
                                     </div>
-                                    <div th:if="${document.getNoDocument() == true}">
+                                    <div th:if="${document.getNoDocument() == true && document.getDocumentSubCategory().name() == 'OTHER_TAX'}">
                                         <span>Pas de document</span>
                                     </div>
                                     <ul>
@@ -1164,7 +1164,7 @@
                                     <div th:if="${document.getMonthlySum()!=null}">
                                         <span th:text="${'Montly sum: '+document.getMonthlySum()}"></span>
                                     </div>
-                                    <div th:if="${document.getNoDocument() == true}">
+                                    <div th:if="${document.getNoDocument() == true && document.getDocumentSubCategory().name() == 'OTHER_TAX'}">
                                         <span>Pas de document</span>
                                     </div>
                                     <ul>

--- a/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/apartment-sharing-view.html
@@ -954,7 +954,7 @@
                                     <div th:if="${document.getMonthlySum()!=null}">
                                         <span th:text="${'Montly sum: '+document.getMonthlySum()}"></span>
                                     </div>
-                                    <div th:if="${document.getNoDocument() == true && document.getDocumentSubCategory().name() == 'OTHER_TAX'}">
+                                    <div th:if="${document.getNoDocument() == true}">
                                         <span>Pas de document</span>
                                     </div>
                                     <ul>
@@ -1164,7 +1164,7 @@
                                     <div th:if="${document.getMonthlySum()!=null}">
                                         <span th:text="${'Montly sum: '+document.getMonthlySum()}"></span>
                                     </div>
-                                    <div th:if="${document.getNoDocument() == true && document.getDocumentSubCategory().name() == 'OTHER_TAX'}">
+                                    <div th:if="${document.getNoDocument() == true}">
                                         <span>Pas de document</span>
                                     </div>
                                     <ul>

--- a/dossierfacile-bo/src/main/resources/templates/bo/fragments/document-analysis.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/fragments/document-analysis.html
@@ -142,7 +142,6 @@
             <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="#000091"><path d="M19.5,2.5h-15c-1.1,0-2,0.9-2,2v15c0,1.1,0.9,2,2,2h15c1.1,0,2-0.9,2-2v-15C21.5,3.4,20.6,2.5,19.5,2.5z M13,17h-2v-6h2V17z M13,9h-2V7h2V9z"/></svg>
             <span>Ce document n'a pas pu être analysé. Il est à traiter manuellement.</span>
         </div>
-        <!-- User custom message -->
     </th:block>
 
 </div>

--- a/dossierfacile-bo/src/main/resources/templates/bo/process-file.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/process-file.html
@@ -77,7 +77,7 @@
                 </div>
                 <div class="row mt-4">
                     <div class="col-md-8" style="min-height: 700px; max-height: 1050px"
-                         th:if="${messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX'}">
+                         th:if="${messageItem.getDocumentName() == null || messageItem.getDocumentName().isBlank()}">
                         <div class="full-size-div">
                             <div class="card-div">
                                 <div class="card" style="background-color: rgb(232, 237, 241)">
@@ -87,7 +87,7 @@
                         </div>
                     </div>
                     <div class="col-md-8 d-flex flex-column" style="min-height: 700px; max-height: 1050px"
-                         th:if="${!(messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX')}">
+                         th:if="${!(messageItem.getDocumentName() == null || messageItem.getDocumentName().isBlank())}">
                         <div class="d-flex justify-content-end mb-2">
                             <button type="button" class="btn btn-outline-info btn-sm"
                                     data-bs-toggle="modal"
@@ -268,7 +268,7 @@
                     <div class="row mt-4">
 
                         <div class="col-md-8" style="min-height: 700px; max-height: 1050px"
-                             th:if="${messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX'}">
+                             th:if="${messageItem.getDocumentName() == null || messageItem.getDocumentName().isBlank()}">
                             <div class="full-size-div">
                                 <div class="card-div">
                                     <div class="card" style="background-color: rgb(232, 237, 241)">
@@ -278,8 +278,7 @@
                             </div>
                         </div>
                         <div class="col-md-8 d-flex flex-column" style="min-height: 700px; max-height: 1050px"
-                             th:if="${!(messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX')}">
-
+                             th:if="${!(messageItem.getDocumentName() == null || messageItem.getDocumentName().isBlank())}">
                             <div class="d-flex justify-content-end mb-2">
                                 <button type="button" class="btn btn-outline-info btn-sm"
                                         data-bs-toggle="modal"

--- a/dossierfacile-bo/src/main/resources/templates/bo/process-file.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/process-file.html
@@ -77,7 +77,7 @@
                 </div>
                 <div class="row mt-4">
                     <div class="col-md-8" style="min-height: 700px; max-height: 1050px"
-                         th:if="${messageItem.getNoDocument() == true}">
+                         th:if="${messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX'}">
                         <div class="full-size-div">
                             <div class="card-div">
                                 <div class="card" style="background-color: rgb(232, 237, 241)">
@@ -87,8 +87,7 @@
                         </div>
                     </div>
                     <div class="col-md-8 d-flex flex-column" style="min-height: 700px; max-height: 1050px"
-                         th:if="${messageItem.getNoDocument() != true}">
-
+                         th:if="${!(messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX')}">
                         <div class="d-flex justify-content-end mb-2">
                             <button type="button" class="btn btn-outline-info btn-sm"
                                     data-bs-toggle="modal"
@@ -269,7 +268,7 @@
                     <div class="row mt-4">
 
                         <div class="col-md-8" style="min-height: 700px; max-height: 1050px"
-                             th:if="${messageItem.getNoDocument() == true}">
+                             th:if="${messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX'}">
                             <div class="full-size-div">
                                 <div class="card-div">
                                     <div class="card" style="background-color: rgb(232, 237, 241)">
@@ -279,7 +278,7 @@
                             </div>
                         </div>
                         <div class="col-md-8 d-flex flex-column" style="min-height: 700px; max-height: 1050px"
-                             th:if="${messageItem.getNoDocument() != true}">
+                             th:if="${!(messageItem.getNoDocument() == true && messageItem.getDocumentSubCategory().name() == 'OTHER_TAX')}">
 
                             <div class="d-flex justify-content-end mb-2">
                                 <button type="button" class="btn btn-outline-info btn-sm"

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/TestBOApplication.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/TestBOApplication.java
@@ -1,0 +1,26 @@
+package fr.gouv.bo;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+
+/**
+ * Minimal Spring Boot application for @WebMvcTest.
+ * Excludes JPA, OAuth2 and datasource auto-configuration
+ * to allow testing controllers with mocked services.
+ */
+@SpringBootApplication(
+        scanBasePackages = "fr.gouv.bo.controller",
+        exclude = {
+                DataSourceAutoConfiguration.class,
+                HibernateJpaAutoConfiguration.class,
+                JpaRepositoriesAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+public class TestBOApplication {
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
@@ -296,12 +296,6 @@ class TaxDisplayTest {
         }
     }
 
-    // ===== Guarantor tests =====
-    // Same scenarios as tenant, applied to a guarantor's tax documents.
-    // Note: there is a known backend bug where DocumentTaxGuarantorNaturalPerson
-    // loses customText when noDocument=false (unlike tenant), see DocumentTaxCustomTextTest.
-    // These tests verify the BO **display** behavior given the data as stored in DB.
-
     @Nested
     class GuarantorOtherTaxWithCustomTextAndNoFile {
 
@@ -337,7 +331,6 @@ class TaxDisplayTest {
     }
 
     @Nested
-    @org.junit.jupiter.api.Disabled("Bug: DocumentTaxGuarantorNaturalPerson loses customText when noDocument=false — see DocumentTaxCustomTextTest")
     class GuarantorOtherTaxWithCustomTextAndFile {
 
         @BeforeEach

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
@@ -1,0 +1,386 @@
+package fr.gouv.bo.controller;
+
+import fr.dossierfacile.common.entity.*;
+import fr.dossierfacile.common.enums.*;
+import fr.dossierfacile.common.enums.TypeGuarantor;
+import fr.dossierfacile.common.repository.LinkLogRepository;
+import fr.dossierfacile.common.service.ApartmentSharingLinkService;
+import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
+import fr.gouv.bo.TestBOApplication;
+import fr.gouv.bo.service.*;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests real Thymeleaf template rendering for tax document display
+ * on both /bo/tenant/{id}/processFile and /bo/colocation/{id} views.
+ */
+@WebMvcTest(controllers = {BOTenantController.class, BOApartmentSharingController.class})
+@ContextConfiguration(classes = {TestBOApplication.class, TaxDisplayTest.TestSecurityConfig.class})
+@ActiveProfiles("test")
+class TaxDisplayTest {
+
+    @Configuration
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            return http.build();
+        }
+
+        @Bean
+        public ClientRegistrationRepository clientRegistrationRepository() {
+            return registrationId -> null;
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // BOTenantController dependencies
+    @MockitoBean
+    private TenantService tenantService;
+    @MockitoBean
+    private MessageService messageService;
+    @MockitoBean
+    private DocumentService documentService;
+    @MockitoBean
+    private UserApiService userApiService;
+    @MockitoBean
+    private PartnerCallBackService partnerCallBackService;
+    @MockitoBean
+    private UserService userService;
+    @MockitoBean
+    private TenantLogService logService;
+    @MockitoBean
+    private DocumentDeniedReasonsService documentDeniedReasonsService;
+
+    // BOApartmentSharingController dependencies
+    @MockitoBean
+    private ApartmentSharingLinkService apartmentSharingLinkService;
+    @MockitoBean
+    private LinkLogRepository linkLogRepository;
+
+    private Tenant tenant;
+
+    @BeforeEach
+    void setUp() {
+        var apartmentSharing = ApartmentSharing.builder()
+                .id(1L)
+                .applicationType(ApplicationType.ALONE)
+                .build();
+        tenant = Tenant.builder()
+                .id(1L)
+                .apartmentSharing(apartmentSharing)
+                .tenantType(TenantType.CREATE)
+                .status(TenantFileStatus.TO_PROCESS)
+                .honorDeclaration(true)
+                .documents(new ArrayList<>())
+                .guarantors(new ArrayList<>())
+                .build();
+        apartmentSharing.setTenants(new ArrayList<>(List.of(tenant)));
+
+        // processFile mocks
+        when(tenantService.find(1L)).thenReturn(tenant);
+        when(logService.getLogByTenantId(anyLong())).thenReturn(Collections.emptyList());
+        when(userApiService.findPartnersLinkedToTenant(anyLong())).thenReturn(Collections.emptyList());
+        when(messageService.findTenantMessages(any())).thenReturn(Collections.emptyList());
+        when(documentDeniedReasonsService.getLastDeniedReason(any(), any())).thenReturn(java.util.Optional.empty());
+
+        // colocation mocks
+        when(tenantService.findAllTenantsByApartmentSharingAndReorderDocumentsByCategory(1L))
+                .thenReturn(new ArrayList<>(List.of(tenant)));
+        when(tenantService.getAllDocumentCategories(any())).thenAnswer(inv -> {
+            Tenant t = inv.getArgument(0);
+            return new ArrayList<>(t.getDocuments());
+        });
+        when(tenantService.getAllDocumentCategoriesGuarantor(any())).thenAnswer(inv -> {
+            Guarantor g = inv.getArgument(0);
+            return new ArrayList<>(g.getDocuments());
+        });
+        when(tenantService.hasVerifiedEmailIfExistsInKeycloak(any())).thenReturn(false);
+        when(apartmentSharingLinkService.getFilteredLinks(any())).thenReturn(Collections.emptyList());
+        when(userApiService.getAllPartners()).thenReturn(Collections.emptyList());
+    }
+
+    private Guarantor addGuarantor() {
+        var guarantor = Guarantor.builder()
+                .id(10L)
+                .tenant(tenant)
+                .typeGuarantor(TypeGuarantor.NATURAL_PERSON)
+                .firstName("Garant")
+                .lastName("Test")
+                .documents(new ArrayList<>())
+                .build();
+        tenant.getGuarantors().add(guarantor);
+        return guarantor;
+    }
+
+    private void addGuarantorDocument(Guarantor guarantor, DocumentCategory category,
+                                      DocumentSubCategory subCategory, Boolean noDocument, String customText) {
+        var doc = fr.dossierfacile.common.entity.Document.builder()
+                .id((long) (guarantor.getDocuments().size() + 200))
+                .documentCategory(category)
+                .documentSubCategory(subCategory)
+                .documentStatus(DocumentStatus.TO_PROCESS)
+                .noDocument(noDocument)
+                .customText(customText)
+                .guarantor(guarantor)
+                .name("gdoc-" + guarantor.getDocuments().size())
+                .files(new ArrayList<>())
+                .build();
+        guarantor.getDocuments().add(doc);
+    }
+
+    private void addTenantDocument(DocumentCategory category, DocumentSubCategory subCategory,
+                                   Boolean noDocument, String customText) {
+        var doc = fr.dossierfacile.common.entity.Document.builder()
+                .id((long) (tenant.getDocuments().size() + 100))
+                .documentCategory(category)
+                .documentSubCategory(subCategory)
+                .documentStatus(DocumentStatus.TO_PROCESS)
+                .noDocument(noDocument)
+                .customText(customText)
+                .tenant(tenant)
+                .name("doc-" + tenant.getDocuments().size())
+                .files(new ArrayList<>())
+                .build();
+        tenant.getDocuments().add(doc);
+    }
+
+    private Document renderProcessFile() throws Exception {
+        String html = mockMvc.perform(get("/bo/tenant/1/processFile"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return Jsoup.parse(html);
+    }
+
+    private Document renderColocation() throws Exception {
+        String html = mockMvc.perform(get("/bo/colocation/1"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return Jsoup.parse(html);
+    }
+
+    @Nested
+    class OtherTaxWithCustomTextAndNoFile {
+
+        @BeforeEach
+        void setUp() {
+            addTenantDocument(DocumentCategory.TAX, DocumentSubCategory.OTHER_TAX,
+                    true, "Je vis à l'étranger depuis 10 ans.");
+        }
+
+        @Test
+        void processFile_shouldShowNoDocumentCardAndCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Je vis à l'étranger depuis 10 ans.");
+        }
+
+        @Test
+        void colocation_shouldShowNoDocumentCardAndCustomText() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Je vis à l'étranger depuis 10 ans.");
+        }
+    }
+
+    @Nested
+    class OtherTaxWithCustomTextAndFile {
+
+        @BeforeEach
+        void setUp() {
+            addTenantDocument(DocumentCategory.TAX, DocumentSubCategory.OTHER_TAX,
+                    false, "Retour de l'étranger, voici mon avis canadien.");
+        }
+
+        @Test
+        void processFile_shouldShowPdfViewerAndCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNotNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Retour de l'étranger, voici mon avis canadien.");
+        }
+
+        @Test
+        void colocation_shouldShowCustomTextWithoutNoDocumentCard() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Retour de l'étranger, voici mon avis canadien.");
+        }
+    }
+
+    @Nested
+    class ParentTaxWithHonorDeclaration {
+
+        @BeforeEach
+        void setUp() {
+            addTenantDocument(DocumentCategory.TAX, DocumentSubCategory.MY_PARENTS,
+                    false, null);
+        }
+
+        @Test
+        void processFile_shouldShowPdfViewerWithoutCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNotNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation")).isNull();
+        }
+
+        @Test
+        void colocation_shouldNotShowNoDocumentCardNorCustomText() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation")).isNull();
+        }
+    }
+
+    // ===== Guarantor tests =====
+    // Same scenarios as tenant, applied to a guarantor's tax documents.
+    // Note: there is a known backend bug where DocumentTaxGuarantorNaturalPerson
+    // loses customText when noDocument=false (unlike tenant), see DocumentTaxCustomTextTest.
+    // These tests verify the BO **display** behavior given the data as stored in DB.
+
+    @Nested
+    class GuarantorOtherTaxWithCustomTextAndNoFile {
+
+        @BeforeEach
+        void setUp() {
+            var guarantor = addGuarantor();
+            addGuarantorDocument(guarantor, DocumentCategory.TAX, DocumentSubCategory.OTHER_TAX,
+                    true, "Le garant réside à l'étranger.");
+        }
+
+        @Test
+        void processFile_shouldShowNoDocumentCardAndCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Le garant réside à l'étranger.");
+        }
+
+        @Test
+        void colocation_shouldShowNoDocumentCardAndCustomText() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Le garant réside à l'étranger.");
+        }
+    }
+
+    @Nested
+    @org.junit.jupiter.api.Disabled("Bug: DocumentTaxGuarantorNaturalPerson loses customText when noDocument=false — see DocumentTaxCustomTextTest")
+    class GuarantorOtherTaxWithCustomTextAndFile {
+
+        @BeforeEach
+        void setUp() {
+            var guarantor = addGuarantor();
+            addGuarantorDocument(guarantor, DocumentCategory.TAX, DocumentSubCategory.OTHER_TAX,
+                    false, "Retour du Canada, voici l'avis canadien du garant.");
+        }
+
+        @Test
+        void processFile_shouldShowPdfViewerAndCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Retour du Canada, voici l'avis canadien du garant.");
+        }
+
+        @Test
+        void colocation_shouldShowCustomTextWithoutNoDocumentCard() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
+                    .isNotNull()
+                    .extracting(Element::text)
+                    .asString().contains("Retour du Canada, voici l'avis canadien du garant.");
+        }
+    }
+
+    @Nested
+    class GuarantorParentTaxWithHonorDeclaration {
+
+        @BeforeEach
+        void setUp() {
+            var guarantor = addGuarantor();
+            addGuarantorDocument(guarantor, DocumentCategory.TAX, DocumentSubCategory.MY_PARENTS,
+                    false, null);
+        }
+
+        @Test
+        void processFile_shouldShowPdfViewerWithoutCustomText() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation")).isNull();
+        }
+
+        @Test
+        void colocation_shouldNotShowNoDocumentCardNorCustomText() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst(".doc-analysis-explanation")).isNull();
+        }
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
@@ -147,6 +147,13 @@ class TaxDisplayTest {
 
     private void addGuarantorDocument(Guarantor guarantor, DocumentCategory category,
                                       DocumentSubCategory subCategory, Boolean noDocument, String customText) {
+        addGuarantorDocument(guarantor, category, subCategory, noDocument, customText,
+                "gdoc-" + guarantor.getDocuments().size());
+    }
+
+    private void addGuarantorDocument(Guarantor guarantor, DocumentCategory category,
+                                      DocumentSubCategory subCategory, Boolean noDocument, String customText,
+                                      String documentName) {
         var doc = fr.dossierfacile.common.entity.Document.builder()
                 .id((long) (guarantor.getDocuments().size() + 200))
                 .documentCategory(category)
@@ -155,7 +162,7 @@ class TaxDisplayTest {
                 .noDocument(noDocument)
                 .customText(customText)
                 .guarantor(guarantor)
-                .name("gdoc-" + guarantor.getDocuments().size())
+                .name(documentName)
                 .files(new ArrayList<>())
                 .build();
         guarantor.getDocuments().add(doc);
@@ -163,6 +170,11 @@ class TaxDisplayTest {
 
     private void addTenantDocument(DocumentCategory category, DocumentSubCategory subCategory,
                                    Boolean noDocument, String customText) {
+        addTenantDocument(category, subCategory, noDocument, customText, "doc-" + tenant.getDocuments().size());
+    }
+
+    private void addTenantDocument(DocumentCategory category, DocumentSubCategory subCategory,
+                                   Boolean noDocument, String customText, String documentName) {
         var doc = fr.dossierfacile.common.entity.Document.builder()
                 .id((long) (tenant.getDocuments().size() + 100))
                 .documentCategory(category)
@@ -171,7 +183,7 @@ class TaxDisplayTest {
                 .noDocument(noDocument)
                 .customText(customText)
                 .tenant(tenant)
-                .name("doc-" + tenant.getDocuments().size())
+                .name(documentName)
                 .files(new ArrayList<>())
                 .build();
         tenant.getDocuments().add(doc);
@@ -201,11 +213,11 @@ class TaxDisplayTest {
         }
 
         @Test
-        void processFile_shouldShowNoDocumentCardAndCustomText() throws Exception {
+        void processFile_shouldShowPdfViewerAndCustomText() throws Exception {
             Document doc = renderProcessFile();
 
-            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNotNull();
-            assertThat(doc.selectFirst("embed.document-embed")).isNull();
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNotNull();
             assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
                     .isNotNull()
                     .extracting(Element::text)
@@ -213,7 +225,7 @@ class TaxDisplayTest {
         }
 
         @Test
-        void colocation_shouldShowNoDocumentCardAndCustomText() throws Exception {
+        void colocation_shouldShowCustomTextAndNoDocumentWhenGeneratedDocumentIsMissing() throws Exception {
             Document doc = renderColocation();
 
             assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNotNull();
@@ -301,10 +313,11 @@ class TaxDisplayTest {
         }
 
         @Test
-        void processFile_shouldShowNoDocumentCardAndCustomText() throws Exception {
+        void processFile_shouldShowPdfViewerAndCustomText() throws Exception {
             Document doc = renderProcessFile();
 
-            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNotNull();
             assertThat(doc.selectFirst(".doc-analysis-explanation__text"))
                     .isNotNull()
                     .extracting(Element::text)
@@ -312,7 +325,7 @@ class TaxDisplayTest {
         }
 
         @Test
-        void colocation_shouldShowNoDocumentCardAndCustomText() throws Exception {
+        void colocation_shouldShowCustomTextAndNoDocumentWhenGeneratedDocumentIsMissing() throws Exception {
             Document doc = renderColocation();
 
             assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNotNull();
@@ -381,6 +394,31 @@ class TaxDisplayTest {
 
             assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNull();
             assertThat(doc.selectFirst(".doc-analysis-explanation")).isNull();
+        }
+    }
+
+    @Nested
+    class MissingGeneratedDocument {
+
+        @BeforeEach
+        void setUp() {
+            addTenantDocument(DocumentCategory.TAX, DocumentSubCategory.OTHER_TAX,
+                    true, "Pas de PDF généré", null);
+        }
+
+        @Test
+        void processFile_shouldShowNoDocumentCardWhenGeneratedDocumentIsMissing() throws Exception {
+            Document doc = renderProcessFile();
+
+            assertThat(doc.selectFirst("h3:containsOwn(Pas de document)")).isNotNull();
+            assertThat(doc.selectFirst("embed.document-embed")).isNull();
+        }
+
+        @Test
+        void colocation_shouldShowNoDocumentLabelWhenGeneratedDocumentIsMissing() throws Exception {
+            Document doc = renderColocation();
+
+            assertThat(doc.selectFirst(":containsOwn(Pas de document)")).isNotNull();
         }
     }
 }

--- a/dossierfacile-bo/src/test/resources/application-test.properties
+++ b/dossierfacile-bo/src/test/resources/application-test.properties
@@ -1,0 +1,12 @@
+logging.config=classpath:logback-test.xml
+security.csp.content=default-src 'self'
+tenant.base.url=http://localhost:9002
+
+# Dummy OAuth2 config to prevent "Client id must not be empty" errors in tests
+spring.security.oauth2.client.registration.keycloak.client-id=test
+spring.security.oauth2.client.registration.keycloak.client-secret=test
+spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+spring.security.oauth2.client.provider.keycloak.authorization-uri=http://localhost/auth
+spring.security.oauth2.client.provider.keycloak.token-uri=http://localhost/token
+spring.security.oauth2.client.provider.keycloak.jwk-set-uri=http://localhost/jwks
+spring.security.oauth2.client.provider.keycloak.user-info-uri=http://localhost/userinfo

--- a/dossierfacile-bo/src/test/resources/logback-test.xml
+++ b/dossierfacile-bo/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Spécifications fonctionnelles

> [!IMPORTANT]
> Un utilisateur peut dans certains champs du formulaire ne pas déposer de document justificatif. En absence de fichier déposé, un document est généré automatiquement à partir d’un template. C’est ce document qui est ensuite visible lors du traitement du dossier par l’opérateur.

Voici les situations possibles :

#### **Compte locataire**

- `FINANCIAL` (si `noDocument=true`) -> doc template, mention via `custom_text`
    - Il s’agit uniquement de la sub_category : `NO_INCOME`
- `RESIDENCY` - `OTHER_RESIDENCY` -> doc template, mention via `custom_text`
- `TAX`
    - `MY_PARENTS` -> doc template, texte fixe
    - `LESS_THAN_YEAR` -> doc template, `custom_text`
    - `OTHER_TAX` + `noDocument=true`
        - `TAX_NO_DECLARATION` -> texte fixe
        - `TAX_NOT_RECEIVED` -> texte fixe
        - sinon -> `custom_text`

#### **Compte garant**

- `RESIDENCY` - `OTHER_RESIDENCY` -> doc template, mention via `custom_text`
- `TAX`
    - `MY_PARENTS` -> doc template, texte fixe
    - `LESS_THAN_YEAR` -> doc template, `custom_text`
    - `OTHER_TAX` + `noDocument=true`
        - `TAX_NO_DECLARATION` -> texte fixe
        - `TAX_NOT_RECEIVED` -> texte fixe
        - sinon -> `custom_text`

**Point important** : `OTHER_TAX` avec `noDocument=false` ne passe pas par template (il faut alors des fichiers).

#### Que cherche-t-on à faire ?

Afficher systématiquement dans le bo sur les pages :

- `bo/tenant/{tenantId}/processFile`
- `bo/colocation/{apartmentSharingId}`

Le `custom_text` lorsqu’il est présent et non null quelque soit la catégorie ou sous-catégorie de document.

Afficher systématiquement le document généré à partir d’un template.

Lorsqu’il n’y a pas de document généré (ce cas ne devrait pas exister normalement), remplacer par une mention “Pas de document”

> [!IMPORTANT]
> Il y a également un bug de persistance du `custom_text` côté `OTHER_TAX` garant, corrigé dans la PR https://github.com/MTES-MCT/dossierfacile-backend/pull/1201

<img width="1322" height="296" alt="Screenshot 2026-03-30 at 15 21 43" src="https://github.com/user-attachments/assets/dcd5a0f5-0406-48a3-9c29-bea233079400" />
<img width="1322" height="300" alt="Screenshot 2026-03-30 at 15 21 51" src="https://github.com/user-attachments/assets/e93951c7-ded7-4f8f-a062-4f01e74710b3" />
<img width="1698" height="461" alt="Screenshot 2026-03-30 at 15 22 14" src="https://github.com/user-attachments/assets/208cf57a-6964-4818-a26e-17b2ae56c101" />
<img width="1691" height="412" alt="Screenshot 2026-03-30 at 15 22 35" src="https://github.com/user-attachments/assets/2e916107-8d92-494d-b16f-27fd686342dc" />

Fixe https://www.notion.so/dossierfacile/Release-Manager-1526cd6935b98099b6d3fe4f7a90ed1c?p=2ce6cd6935b98088b44ece954e35e90c&pm=s et le revert associé [f71643681ee98aff40c471c751b05bf1f6a920eb ](https://github.com/MTES-MCT/dossierfacile-backend/commit/f71643681ee98aff40c471c751b05bf1f6a920eb)