### PR TITLE
feat(document-analysis): refactor payslip validation and introduce IdentityMatchUtil

### DIFF
--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
@@ -1,0 +1,16 @@
+package fr.dossierfacile.common.entity.rule;
+
+import java.util.List;
+
+public record PayslipNamesRuleData(Name expectedName, List<String> extractedIdentities) implements RuleData {
+   public PayslipNamesRuleData(PayslipNamesRuleData other, List<String> extractedIdentities) {
+      this(other.expectedName, List.copyOf(extractedIdentities));
+   }
+
+   public String getType() {
+      return R_PAYSLIP_NAMES;
+   }
+
+   public static record Name(String firstNames, String lastName, String preferredName) {
+   }
+}

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/RuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/RuleData.java
@@ -15,14 +15,16 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = TaxYearsRuleData.class, name = RuleData.R_TAX_YEARS),
         @JsonSubTypes.Type(value = TaxNamesRuleData.class, name = RuleData.R_TAX_NAMES),
         @JsonSubTypes.Type(value = PayslipContinuityRuleData.class, name = RuleData.R_PAYSLIP_CONTINUITY),
+        @JsonSubTypes.Type(value = PayslipNamesRuleData.class, name = RuleData.R_PAYSLIP_NAMES),
 })
-public sealed interface RuleData permits ExpirationRuleData, NamesRuleData, PayslipContinuityRuleData, TaxClassificationRuleData, TaxNamesRuleData, TaxYearsRuleData {
+public sealed interface RuleData permits ExpirationRuleData, NamesRuleData, PayslipContinuityRuleData, PayslipNamesRuleData, TaxClassificationRuleData, TaxNamesRuleData, TaxYearsRuleData {
     String R_EXPIRATION = "R_EXPIRATION";
     String R_TAX_CLASSIFICATION = "R_TAX_CLASSIFICATION";
     String R_TAX_YEARS = "R_TAX_YEARS";
     String R_TAX_NAMES = "R_TAX_NAMES";
     String R_NAMES = "R_NAMES";
     String R_PAYSLIP_CONTINUITY = "R_PAYSLIP_CONTINUITY";
+    String R_PAYSLIP_NAMES = "R_PAYSLIP_NAMES";
 
     String getType();
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/GenericProperty.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/GenericProperty.java
@@ -107,7 +107,7 @@ public class GenericProperty implements Serializable {
         }
 
         return values.stream()
-                .map(item -> toGenericProperty(item, name, "object"))
+                .map(item -> toGenericProperty(item, name, TYPE_OBJECT))
                 .toList();
     }
 
@@ -127,7 +127,7 @@ public class GenericProperty implements Serializable {
 
         return values.stream()
                 .map(item -> {
-                    GenericProperty listItem = toGenericProperty(item, name, "list");
+                    GenericProperty listItem = toGenericProperty(item, name, TYPE_LIST);
                     if (!TYPE_OBJECT.equals(listItem.getType())) {
                         throw new IllegalArgumentException("Unsupported list item property type for '" + name + "': " + listItem.getType());
                     }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/GenericProperty.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/GenericProperty.java
@@ -15,6 +15,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Data
 @Builder
@@ -105,12 +107,7 @@ public class GenericProperty implements Serializable {
         }
 
         return values.stream()
-                .map(item -> {
-                    if (!(item instanceof GenericProperty gp)) {
-                        throw new IllegalArgumentException("Unsupported nested item type for object property '" + name + "': " + item.getClass());
-                    }
-                    return gp;
-                })
+                .map(item -> toGenericProperty(item, name, "object"))
                 .toList();
     }
 
@@ -130,9 +127,7 @@ public class GenericProperty implements Serializable {
 
         return values.stream()
                 .map(item -> {
-                    if (!(item instanceof GenericProperty listItem)) {
-                        throw new IllegalArgumentException("Unsupported list item type for list property '" + name + "': " + item.getClass());
-                    }
+                    GenericProperty listItem = toGenericProperty(item, name, "list");
                     if (!TYPE_OBJECT.equals(listItem.getType())) {
                         throw new IllegalArgumentException("Unsupported list item property type for '" + name + "': " + listItem.getType());
                     }
@@ -140,5 +135,35 @@ public class GenericProperty implements Serializable {
                     return objectValue == null ? List.<GenericProperty>of() : objectValue;
                 })
                 .toList();
+    }
+
+    private GenericProperty toGenericProperty(Object item, String propertyName, String context) {
+        if (item instanceof GenericProperty gp) {
+            return gp;
+        }
+
+        if (item instanceof Map<?, ?> mapItem) {
+            validateStrictGenericPropertyMap(mapItem, propertyName);
+            return GenericProperty.builder()
+                    .name((String) mapItem.get("name"))
+                    .value(mapItem.get("value"))
+                    .type((String) mapItem.get("type"))
+                    .build();
+        }
+
+        throw new IllegalArgumentException("Unsupported " + context + " item type for property '" + propertyName + "': "
+                + (item == null ? "null" : item.getClass()));
+    }
+
+    private void validateStrictGenericPropertyMap(Map<?, ?> mapItem, String propertyName) {
+        Set<?> keys = mapItem.keySet();
+        if (!keys.equals(Set.of("name", "value", "type"))) {
+            throw new IllegalArgumentException("Unsupported object schema for property '" + propertyName
+                    + "'. Expected keys: [name, value, type], found: " + keys);
+        }
+        if (!(mapItem.get("name") instanceof String) || !(mapItem.get("type") instanceof String)) {
+            throw new IllegalArgumentException("Unsupported object schema for property '" + propertyName
+                    + "'. 'name' and 'type' must be strings");
+        }
     }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/FeatureFlagRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/FeatureFlagRepository.java
@@ -3,6 +3,9 @@ package fr.dossierfacile.common.repository;
 import fr.dossierfacile.common.entity.FeatureFlag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeatureFlagRepository extends JpaRepository<FeatureFlag, String> {
+    List<FeatureFlag> findAllByOrderByCreatedAtDesc();
 }
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/FeatureFlagServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/FeatureFlagServiceImpl.java
@@ -137,7 +137,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
 
     @Transactional(readOnly = true)
     public List<FeatureFlag> getAllFeatureFlags() {
-        return featureFlagRepository.findAll();
+        return featureFlagRepository.findAllByOrderByCreatedAtDesc();
     }
 
     // Private package

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/model/document_ia/GenericPropertyTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/model/document_ia/GenericPropertyTest.java
@@ -1,0 +1,58 @@
+package fr.dossierfacile.common.model.document_ia;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GenericPropertyTest {
+
+    @Test
+    void should_map_object_value_from_strict_map_schema() {
+        GenericProperty beneficiaire = GenericProperty.builder()
+                .name("beneficiaire")
+                .type(GenericProperty.TYPE_OBJECT)
+                .value(List.of(
+                        nested("ligne1", "MR HALDENWANG TOURNESAC ROMARIC", "string"),
+                        nested("qualite", null, "string"),
+                        nested("prenom", null, "string"),
+                        nested("nom", null, "string")
+                ))
+                .build();
+
+        List<GenericProperty> mapped = beneficiaire.getObjectValue();
+
+        assertThat(mapped).hasSize(4);
+        assertThat(mapped).extracting(GenericProperty::getName)
+                .containsExactly("ligne1", "qualite", "prenom", "nom");
+        assertThat(mapped).extracting(GenericProperty::getType)
+                .containsOnly("string");
+    }
+
+    @Test
+    void should_reject_non_strict_object_schema() {
+        GenericProperty beneficiaire = GenericProperty.builder()
+                .name("beneficiaire")
+                .type(GenericProperty.TYPE_OBJECT)
+                .value(List.of(
+                        Map.of("name", "ligne1", "value", "X", "type", "string", "extra", "forbidden")
+                ))
+                .build();
+
+        assertThatThrownBy(beneficiaire::getObjectValue)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected keys: [name, value, type]");
+    }
+
+    private Map<String, Object> nested(String name, Object value, String type) {
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("name", name);
+        nested.put("value", value);
+        nested.put("type", type);
+        return nested;
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/BulletinSalaireRulesValidationService.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/BulletinSalaireRulesValidationService.java
@@ -6,7 +6,7 @@ import fr.dossierfacile.document.analysis.rule.validator.AbstractDocumentRuleVal
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.ClassificationValidatorB;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.HasBeenDocumentIAAnalysedBI;
 import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipContinuityRule;
-import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipNameMatch;
+import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipNamesRule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +29,7 @@ public class BulletinSalaireRulesValidationService extends AbstractRulesValidati
         return List.of(
                 new HasBeenDocumentIAAnalysedBI(),
                 new ClassificationValidatorB(DOCUMENT_IA_DOCUMENT_TYPE),
-                new PayslipNameMatch(),
+                new PayslipNamesRule(),
                 new PayslipContinuityRule()
         );
     }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNameMatch.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNameMatch.java
@@ -8,7 +8,7 @@ import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAMultiMapper;
 import fr.dossierfacile.document.analysis.rule.validator.payslip.document_ia_model.PayslipNames;
-import fr.dossierfacile.document.analysis.util.NameUtil;
+import fr.dossierfacile.document.analysis.rule.validator.util.IdentityMatchUtil;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -46,7 +46,6 @@ public class PayslipNameMatch extends BaseDocumentIAValidator {
                     nameToMatch.getLastName(),
                     nameToMatch.getPreferredName()
             );
-
             namesRuleData = new NamesRuleData(expectedName, List.of());
         }
 
@@ -58,28 +57,34 @@ public class PayslipNameMatch extends BaseDocumentIAValidator {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
         }
 
-        var isNameMatch = true;
+        var extractedPayslips = new DocumentIAMultiMapper().map(documentIAAnalyses, PayslipNames.class);
 
-        var extractedIdentities = new DocumentIAMultiMapper().map(documentIAAnalyses, PayslipNames.class);
-
-        var listOfExtractedNames = new ArrayList<NamesRuleData.Name>();
-        for (PayslipNames name : extractedIdentities) {
-            if (!NameUtil.isNameMatching(nameToMatch, name)) {
-                isNameMatch = false;
-            }
-            listOfExtractedNames.add(
-                    new NamesRuleData.Name(
-                            String.join(" ", name.getFirstNames()),
-                            name.getLastName(),
-                            null
-                    )
-            );
+        if (extractedPayslips.isEmpty()) {
+            return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
         }
 
-        namesRuleData = new NamesRuleData(
-                namesRuleData,
-                listOfExtractedNames
-        );
+        var listOfExtractedNames = new ArrayList<NamesRuleData.Name>();
+        var isNameMatch = true;
+
+        for (PayslipNames payslip : extractedPayslips) {
+            String identityString = payslip.getIdentityString();
+            listOfExtractedNames.add(new NamesRuleData.Name(null, identityString, null));
+
+            if (identityString == null) {
+                isNameMatch = false;
+                continue;
+            }
+
+            List<String> identities = List.of(identityString);
+            boolean lastNameMatches = IdentityMatchUtil.hasLastNameMatch(identities, nameToMatch);
+            boolean firstNameMatches = IdentityMatchUtil.hasFirstNameMatch(identities, nameToMatch);
+
+            if (!lastNameMatches || !firstNameMatches) {
+                isNameMatch = false;
+            }
+        }
+
+        namesRuleData = new NamesRuleData(namesRuleData, listOfExtractedNames);
 
         if (isNameMatch) {
             return new RuleValidatorOutput(true, isBlocking(), DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.PASSED);

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
@@ -3,7 +3,7 @@ package fr.dossierfacile.document.analysis.rule.validator.payslip;
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentAnalysisRule;
 import fr.dossierfacile.common.entity.DocumentRule;
-import fr.dossierfacile.common.entity.rule.NamesRuleData;
+import fr.dossierfacile.common.entity.rule.PayslipNamesRuleData;
 import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAMultiMapper;
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
-public class PayslipNameMatch extends BaseDocumentIAValidator {
+public class PayslipNamesRule extends BaseDocumentIAValidator {
 
     @Override
     protected boolean isBlocking() {
@@ -38,15 +38,15 @@ public class PayslipNameMatch extends BaseDocumentIAValidator {
 
         var nameToMatch = getNamesFromDocument(document);
 
-        NamesRuleData namesRuleData = null;
+        PayslipNamesRuleData namesRuleData = null;
 
         if (nameToMatch != null) {
-            var expectedName = new NamesRuleData.Name(
+            var expectedName = new PayslipNamesRuleData.Name(
                     nameToMatch.getFirstNamesAsString(),
                     nameToMatch.getLastName(),
                     nameToMatch.getPreferredName()
             );
-            namesRuleData = new NamesRuleData(expectedName, List.of());
+            namesRuleData = new PayslipNamesRuleData(expectedName, List.of());
         }
 
         if (documentIAAnalyses.isEmpty() || hasAnyNonSuccessfulDocumentIAAnalyses(document)) {
@@ -63,12 +63,12 @@ public class PayslipNameMatch extends BaseDocumentIAValidator {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
         }
 
-        var listOfExtractedNames = new ArrayList<NamesRuleData.Name>();
+        var listOfExtractedIdentities = new ArrayList<String>();
         var isNameMatch = true;
 
         for (PayslipNames payslip : extractedPayslips) {
             String identityString = payslip.getIdentityString();
-            listOfExtractedNames.add(new NamesRuleData.Name(null, identityString, null));
+            listOfExtractedIdentities.add(identityString);
 
             if (identityString == null) {
                 isNameMatch = false;
@@ -84,7 +84,7 @@ public class PayslipNameMatch extends BaseDocumentIAValidator {
             }
         }
 
-        namesRuleData = new NamesRuleData(namesRuleData, listOfExtractedNames);
+        namesRuleData = new PayslipNamesRuleData(namesRuleData, listOfExtractedIdentities);
 
         if (isNameMatch) {
             return new RuleValidatorOutput(true, isBlocking(), DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.PASSED);

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
@@ -14,6 +14,40 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
 import java.util.List;
 
+/*
+ * Rule R_PAYSLIP_NAME_MATCH:
+ *
+ * Cette regle verifie que l'identite extraite d'un bulletin de salaire correspond
+ * a l'identite du locataire (ou garant selon le document porteur).
+ *
+ * Pourquoi cette logique est specifique:
+ * - L'identite du bulletin est extraite par Document-IA sous forme de chaine libre
+ *   (identityString).
+ * - On ne dispose pas toujours d'un decoupage fiable nom/prenom directement exploitable.
+ * - Les variantes usuelles doivent rester acceptees: accents, espaces, nom d'usage
+ *   (preferredName), etc.
+ *
+ * Strategie de matching appliquee :
+ * 1) Recuperation des analyses IA exploitables
+ *    - On ne retient que les analyses IA en succes.
+ *    - Si une analyse est absente ou non aboutie, la regle devient INCONCLUSIVE.
+ * 2) Construction des donnees d'audit
+ *    - On construit le nom attendu (prenom(s), nom, preferredName) depuis le dossier.
+ *    - On trace egalement toutes les identites extraites du bulletin pour expliciter
+ *      ce qui a ete compare dans la RuleData.
+ * 3) Verification nom + prenom pour chaque bulletin extrait
+ *    - Pour chaque identityString, on applique le moteur commun IdentityMatchUtil.
+ *    - Le nom (lastName/preferredName) et le prenom doivent tous deux matcher.
+ * 4) Decision finale
+ *    - PASSED uniquement si toutes les identites extraites exploitables matchent.
+ *    - FAILED des qu'une identite est manquante ou non correspondante.
+ *    - INCONCLUSIVE si aucune extraction exploitable n'est disponible ou si l'identite
+ *      attendue est absente.
+ *
+ * Intention metier :
+ * - Maintenir une verification robuste de l'appartenance du bulletin au candidat,
+ *   tout en limitant les faux negatifs lies aux variations d'ecriture des noms.
+ */
 @Slf4j
 public class PayslipNamesRule extends BaseDocumentIAValidator {
 

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/BeneficiaireModel.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/BeneficiaireModel.java
@@ -1,0 +1,30 @@
+package fr.dossierfacile.document.analysis.rule.validator.payslip.document_ia_model;
+
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAField;
+import lombok.Setter;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Setter
+public class BeneficiaireModel {
+
+    @DocumentIAField(extractionName = "ligne1")
+    public String ligne1;
+
+    @DocumentIAField(extractionName = "nom")
+    public String nom;
+
+    @DocumentIAField(extractionName = "prenom")
+    public String prenom;
+
+    // ligne1 en priorité, puis concaténation des valeurs non-nulles parmi prenom / nom
+    public String resolveIdentityString() {
+        if (ligne1 != null) return ligne1;
+        String result = Stream.of(nom, prenom)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(" "));
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/PayslipDate.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/PayslipDate.java
@@ -12,19 +12,13 @@ import java.time.LocalDate;
 @DocumentIAModel(documentCategory = DocumentCategory.FINANCIAL, documentSubCategory = DocumentSubCategory.SALARY)
 public class PayslipDate {
 
-    @DocumentIAField(
-            extractionName = "periode_debut"
-    )
+    @DocumentIAField(twoDDocName = "debut_periode", extractionName = "periode_debut")
     public LocalDate startDate;
 
-    @DocumentIAField(
-            extractionName = "periode_fin"
-    )
+    @DocumentIAField(twoDDocName = "fin_periode", extractionName = "periode_fin")
     public LocalDate endDate;
 
-    @DocumentIAField(
-            extractionName = "date_paiement"
-    )
+    @DocumentIAField(extractionName = "date_paiement")
     public LocalDate paymentDate;
 
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/PayslipNames.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/document_ia_model/PayslipNames.java
@@ -2,42 +2,25 @@ package fr.dossierfacile.document.analysis.rule.validator.payslip.document_ia_mo
 
 import fr.dossierfacile.common.enums.DocumentCategory;
 import fr.dossierfacile.common.enums.DocumentSubCategory;
-import fr.dossierfacile.common.utils.IDocumentIdentity;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAField;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAModel;
 import lombok.Setter;
 
-import java.util.List;
-
 @Setter
 @DocumentIAModel(documentCategory = DocumentCategory.FINANCIAL, documentSubCategory = DocumentSubCategory.SALARY)
-public class PayslipNames implements IDocumentIdentity {
+public class PayslipNames {
 
-    @DocumentIAField(
-            extractionName = "nom_salarie"
-    )
-    public String lastName;
+    @DocumentIAField(twoDDocName = "beneficiaire")
+    public BeneficiaireModel beneficiaire;
 
-    @DocumentIAField(
-            extractionName = "prenom_salarie"
-    )
-    public String firstName;
+    @DocumentIAField(extractionName = "identite_salarie")
+    public String identiteString;
 
-    @Override
-    public List<String> getFirstNames() {
-        if (firstName != null) {
-            return List.of(firstName);
+    public String getIdentityString() {
+        if (beneficiaire != null) {
+            String fromBeneficiaire = beneficiaire.resolveIdentityString();
+            if (fromBeneficiaire != null) return fromBeneficiaire;
         }
-        return List.of();
-    }
-
-    @Override
-    public String getLastName() {
-        return lastName;
-    }
-
-    @Override
-    public String getPreferredName() {
-        return null;
+        return identiteString;
     }
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/tax/TaxNamesRule.java
@@ -8,12 +8,9 @@ import fr.dossierfacile.common.entity.rule.TaxNamesRuleData;
 import fr.dossierfacile.common.model.document_ia.BarcodeModel;
 import fr.dossierfacile.common.model.document_ia.GenericProperty;
 import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
-import fr.dossierfacile.document.analysis.rule.validator.french_identity_card.document_ia_model.DocumentIdentity;
-import org.apache.commons.text.similarity.LevenshteinDistance;
+import fr.dossierfacile.document.analysis.rule.validator.util.IdentityMatchUtil;
 
-import java.text.Normalizer;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -57,9 +54,6 @@ import java.util.stream.Stream;
  *   sans perdre la sécurité apportée par une vérification explicite nom + prénom.
  */
 public class TaxNamesRule extends BaseTaxRule {
-
-    private static final int LAST_NAME_MAX_DISTANCE = 2;
-    private static final int MIN_LENGTH_FOR_LEVENSHTEIN = 4;
 
     @Override
     protected boolean isBlocking() {
@@ -107,13 +101,13 @@ public class TaxNamesRule extends BaseTaxRule {
 
         namesRuleData = new TaxNamesRuleData(namesRuleData, listOfBarcodeIdentities);
 
-        var hasLastNameMatch = hasLastNameMatch(listOfBarcodeIdentities, nameToMatch);
+        var hasLastNameMatch = IdentityMatchUtil.hasLastNameMatch(listOfBarcodeIdentities, nameToMatch);
 
         if (!hasLastNameMatch) {
             return reject(namesRuleData);
         }
 
-        var hasFirstNameMatch = hasFirstNameMatch(listOfBarcodeIdentities, nameToMatch);
+        var hasFirstNameMatch = IdentityMatchUtil.hasFirstNameMatch(listOfBarcodeIdentities, nameToMatch);
 
         if (!hasFirstNameMatch) {
             return reject(namesRuleData);
@@ -145,112 +139,5 @@ public class TaxNamesRule extends BaseTaxRule {
                 .map(GenericProperty::getStringValue)
                 .filter(Objects::nonNull)
                 .toList();
-    }
-
-    private boolean hasFirstNameMatch(List<String> barcodeIdentities, DocumentIdentity documentIdentity) {
-        if (documentIdentity == null) {
-            return false;
-        }
-
-        List<String> firstNamesToMatch = documentIdentity.getFirstNames().stream()
-                .map(this::normalize)
-                .filter(name -> !name.isBlank())
-                .flatMap(name -> Stream.of(name, name.replaceAll("[-'_]", " ")))
-                .flatMap(this::splitTokens)
-                .distinct()
-                .toList();
-
-        return hasIdentityMatch(barcodeIdentities, firstNamesToMatch, false);
-    }
-
-    private boolean hasLastNameMatch(List<String> barcodeIdentities, DocumentIdentity documentIdentity) {
-        if (documentIdentity == null) {
-            return false;
-        }
-
-        List<String> lastNamesToMatch = Stream.of(documentIdentity.getLastName(), documentIdentity.getPreferredName())
-                .map(this::normalize)
-                .filter(name -> !name.isBlank())
-                .flatMap(this::lastNameVariants)
-                .distinct()
-                .toList();
-
-        return hasIdentityMatch(barcodeIdentities, lastNamesToMatch, true);
-    }
-
-    private Stream<String> lastNameVariants(String normalizedName) {
-        Stream<String> baseVariants = Stream.of(
-                normalizedName,
-                normalizedName.replaceAll("[-'_]", " ")
-        );
-
-        Stream<String> composedVariant = Stream.empty();
-        List<String> tokens = splitTokens(normalizedName).toList();
-        
-        if (tokens.size() >= 2 ) { // normalizedName is composed
-            // filter out short last names otherwise rule is too permissive
-            composedVariant = tokens.stream()
-                .filter(token -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
-                .map(token -> token.replaceAll("[-'_]", " "));
-        }
-
-        return Stream.concat(baseVariants, composedVariant);
-    }
-
-    private boolean hasIdentityMatch(List<String> barcodeIdentities, List<String> expectedTokens, boolean strictOnWholeIdentity) {
-        if (barcodeIdentities == null || barcodeIdentities.isEmpty() || expectedTokens.isEmpty()) {
-            return false;
-        }
-
-        List<String> normalizedIdentities = barcodeIdentities.stream()
-                .map(this::normalize)
-                .filter(identity -> !identity.isBlank())
-                .toList();
-
-        if (normalizedIdentities.isEmpty()) {
-            return false;
-        }
-
-        boolean strictMatch;
-        if (strictOnWholeIdentity) {
-            strictMatch = normalizedIdentities.stream()
-                    .anyMatch(identity -> expectedTokens.stream().anyMatch(identity::contains));
-        } else {
-            strictMatch = normalizedIdentities.stream()
-                    .flatMap(this::splitTokens)
-                    .anyMatch(token -> expectedTokens.stream().anyMatch(token::contains));
-        }
-
-        if (strictMatch) {
-            return true;
-        }
-
-        LevenshteinDistance levenshtein = LevenshteinDistance.getDefaultInstance();
-        return normalizedIdentities.stream()
-                .flatMap(this::splitTokens)
-                .anyMatch(token -> expectedTokens.stream()
-                        .filter(expectedToken -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN
-                                && expectedToken.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
-                        .anyMatch(expectedToken -> {
-                            Integer distance = levenshtein.apply(token, expectedToken);
-                            return distance != null && distance <= LAST_NAME_MAX_DISTANCE;
-                        }));
-    }
-
-    private Stream<String> splitTokens(String identity) {
-        return TOKEN_SEPARATOR.splitAsStream(identity)
-                .filter(Objects::nonNull)
-                .filter(token -> !token.isBlank());
-    }
-
-    private String normalize(String value) {
-        if (value == null) {
-            return "";
-        }
-
-        String noAccent = Normalizer.normalize(value, Normalizer.Form.NFD)
-                .replaceAll("\\p{M}+", "");
-
-        return noAccent.trim().toUpperCase(Locale.ROOT);
     }
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/util/IdentityMatchUtil.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/util/IdentityMatchUtil.java
@@ -1,0 +1,126 @@
+package fr.dossierfacile.document.analysis.rule.validator.util;
+
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+import fr.dossierfacile.document.analysis.rule.validator.french_identity_card.document_ia_model.DocumentIdentity;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+
+import java.text.Normalizer;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public final class IdentityMatchUtil {
+
+    private static final int LAST_NAME_MAX_DISTANCE = 2;
+    private static final int MIN_LENGTH_FOR_LEVENSHTEIN = 4;
+
+    private IdentityMatchUtil() {
+    }
+
+    public static boolean hasFirstNameMatch(List<String> identities, DocumentIdentity documentIdentity) {
+        if (documentIdentity == null) {
+            return false;
+        }
+
+        List<String> firstNamesToMatch = documentIdentity.getFirstNames().stream()
+                .map(IdentityMatchUtil::normalize)
+                .filter(name -> !name.isBlank())
+                .flatMap(name -> Stream.of(name, name.replaceAll("[-'_]", " ")))
+                .flatMap(IdentityMatchUtil::splitTokens)
+                .distinct()
+                .toList();
+
+        return hasIdentityMatch(identities, firstNamesToMatch, false);
+    }
+
+    public static boolean hasLastNameMatch(List<String> identities, DocumentIdentity documentIdentity) {
+        if (documentIdentity == null) {
+            return false;
+        }
+
+        List<String> lastNamesToMatch = Stream.of(documentIdentity.getLastName(), documentIdentity.getPreferredName())
+                .map(IdentityMatchUtil::normalize)
+                .filter(name -> !name.isBlank())
+                .flatMap(IdentityMatchUtil::lastNameVariants)
+                .distinct()
+                .toList();
+
+        return hasIdentityMatch(identities, lastNamesToMatch, true);
+    }
+
+    public static boolean hasIdentityMatch(List<String> identities, List<String> expectedTokens, boolean strictOnWholeIdentity) {
+        if (identities == null || identities.isEmpty() || expectedTokens.isEmpty()) {
+            return false;
+        }
+
+        List<String> normalizedIdentities = identities.stream()
+                .map(IdentityMatchUtil::normalize)
+                .filter(identity -> !identity.isBlank())
+                .toList();
+
+        if (normalizedIdentities.isEmpty()) {
+            return false;
+        }
+
+        boolean strictMatch;
+        if (strictOnWholeIdentity) {
+            strictMatch = normalizedIdentities.stream()
+                    .anyMatch(identity -> expectedTokens.stream().anyMatch(identity::contains));
+        } else {
+            strictMatch = normalizedIdentities.stream()
+                    .flatMap(IdentityMatchUtil::splitTokens)
+                    .anyMatch(token -> expectedTokens.stream().anyMatch(token::contains));
+        }
+
+        if (strictMatch) {
+            return true;
+        }
+
+        LevenshteinDistance levenshtein = LevenshteinDistance.getDefaultInstance();
+        return normalizedIdentities.stream()
+                .flatMap(IdentityMatchUtil::splitTokens)
+                .anyMatch(token -> expectedTokens.stream()
+                        .filter(expectedToken -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN
+                                && expectedToken.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
+                        .anyMatch(expectedToken -> {
+                            Integer distance = levenshtein.apply(token, expectedToken);
+                            return distance != null && distance <= LAST_NAME_MAX_DISTANCE;
+                        }));
+    }
+
+    public static Stream<String> splitTokens(String identity) {
+        return BaseDocumentIAValidator.TOKEN_SEPARATOR.splitAsStream(identity)
+                .filter(Objects::nonNull)
+                .filter(token -> !token.isBlank());
+    }
+
+    public static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String noAccent = Normalizer.normalize(value, Normalizer.Form.NFD)
+                .replaceAll("\\p{M}+", "");
+
+        return noAccent.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private static Stream<String> lastNameVariants(String normalizedName) {
+        Stream<String> baseVariants = Stream.of(
+                normalizedName,
+                normalizedName.replaceAll("[-'_]", " ")
+        );
+
+        Stream<String> composedVariant = Stream.empty();
+        List<String> tokens = splitTokens(normalizedName).toList();
+
+        if (tokens.size() >= 2) {
+            composedVariant = tokens.stream()
+                    .filter(token -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
+                    .map(token -> token.replaceAll("[-'_]", " "));
+        }
+
+        return Stream.concat(baseVariants, composedVariant);
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/util/IdentityMatchUtil.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/util/IdentityMatchUtil.java
@@ -14,6 +14,7 @@ public final class IdentityMatchUtil {
 
     private static final int LAST_NAME_MAX_DISTANCE = 2;
     private static final int MIN_LENGTH_FOR_LEVENSHTEIN = 4;
+    private static final String NAME_SEPARATOR_REGEX = "[-'_]";
 
     private IdentityMatchUtil() {
     }
@@ -26,7 +27,7 @@ public final class IdentityMatchUtil {
         List<String> firstNamesToMatch = documentIdentity.getFirstNames().stream()
                 .map(IdentityMatchUtil::normalize)
                 .filter(name -> !name.isBlank())
-                .flatMap(name -> Stream.of(name, name.replaceAll("[-'_]", " ")))
+                .flatMap(name -> Stream.of(name, name.replaceAll(NAME_SEPARATOR_REGEX, " ")))
                 .flatMap(IdentityMatchUtil::splitTokens)
                 .distinct()
                 .toList();
@@ -109,7 +110,7 @@ public final class IdentityMatchUtil {
     private static Stream<String> lastNameVariants(String normalizedName) {
         Stream<String> baseVariants = Stream.of(
                 normalizedName,
-                normalizedName.replaceAll("[-'_]", " ")
+                normalizedName.replaceAll(NAME_SEPARATOR_REGEX, " ")
         );
 
         Stream<String> composedVariant = Stream.empty();
@@ -118,7 +119,7 @@ public final class IdentityMatchUtil {
         if (tokens.size() >= 2) {
             composedVariant = tokens.stream()
                     .filter(token -> token.length() >= MIN_LENGTH_FOR_LEVENSHTEIN)
-                    .map(token -> token.replaceAll("[-'_]", " "));
+                    .map(token -> token.replaceAll(NAME_SEPARATOR_REGEX, " "));
         }
 
         return Stream.concat(baseVariants, composedVariant);

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
@@ -4,6 +4,7 @@ import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.File;
 import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
 import fr.dossierfacile.common.model.document_ia.ExtractionModel;
 import fr.dossierfacile.common.model.document_ia.GenericProperty;
 import fr.dossierfacile.common.model.document_ia.ResultModel;
@@ -73,6 +74,34 @@ class PayslipContinuityRuleTest {
         ResultModel result = ResultModel.builder()
                 .extraction(extraction)
                 .barcodes(Collections.emptyList())
+                .build();
+
+        return DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(result)
+                .build();
+    }
+
+    private DocumentIAFileAnalysis analysisWithDateFrom2DDoc(LocalDate startDate, LocalDate endDate) {
+        BarcodeModel barcode = BarcodeModel.builder()
+                .type("DATA_MATRIX")
+                .typedData(List.of(
+                        GenericProperty.builder()
+                                .name("debut_periode")
+                                .type("date")
+                                .value(startDate.toString())
+                                .build(),
+                        GenericProperty.builder()
+                                .name("fin_periode")
+                                .type("date")
+                                .value(endDate.toString())
+                                .build()
+                ))
+                .build();
+
+        ResultModel result = ResultModel.builder()
+                .extraction(null)
+                .barcodes(List.of(barcode))
                 .build();
 
         return DocumentIAFileAnalysis.builder()
@@ -183,6 +212,62 @@ class PayslipContinuityRuleTest {
         RuleValidatorOutput result = validator.validate(document);
 
         assertThat(result.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("Devrait être PASSED si 3 mois consécutifs proviennent des champs 2DDOC (debut_periode / fin_periode)")
+    void should_pass_when_dates_come_from_2d_doc() {
+        PayslipContinuityRule validator = createValidator(LocalDate.of(2023, 4, 10));
+
+        DocumentIAFileAnalysis[] analyses = new DocumentIAFileAnalysis[]{
+                analysisWithDateFrom2DDoc(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 31)),
+                analysisWithDateFrom2DDoc(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28)),
+                analysisWithDateFrom2DDoc(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31))
+        };
+
+        Document document = createDocumentWithAnalyses(analyses);
+        RuleValidatorOutput result = validator.validate(document);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("2DDOC (debut_periode) a priorité sur extraction (periode_debut) quand les deux sont présents")
+    void should_use_2d_doc_date_over_extraction_when_both_present() {
+        PayslipContinuityRule validator = createValidator(LocalDate.of(2023, 4, 10));
+
+        // 2DDOC dit Mars, extraction dit Juillet (hors fenêtre) → seul Mars doit être retenu
+        BarcodeModel barcode = BarcodeModel.builder()
+                .type("DATA_MATRIX")
+                .typedData(List.of(
+                        GenericProperty.builder().name("debut_periode").type("date").value("2023-03-01").build(),
+                        GenericProperty.builder().name("fin_periode").type("date").value("2023-03-31").build()
+                ))
+                .build();
+        ExtractionModel extraction = ExtractionModel.builder()
+                .properties(List.of(
+                        GenericProperty.builder().name("periode_debut").type("date").value("2023-07-01").build(),
+                        GenericProperty.builder().name("periode_fin").type("date").value("2023-07-31").build()
+                ))
+                .build();
+        ResultModel result = ResultModel.builder().extraction(extraction).barcodes(List.of(barcode)).build();
+        DocumentIAFileAnalysis combinedAnalysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(result)
+                .build();
+
+        // Avec seulement 1 bulletin = mois de Mars → pas 3 consécutifs → FAILED (pas INCONCLUSIVE)
+        // Ce test vérifie que c'est le mois de Mars (2DDOC) et non Juillet (extraction) qui est pris
+        DocumentIAFileAnalysis m2 = analysisWithDateFrom2DDoc(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28));
+        DocumentIAFileAnalysis m1 = analysisWithDateFrom2DDoc(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31));
+
+        Document document = createDocumentWithAnalyses(combinedAnalysis, m2, m1);
+        RuleValidatorOutput output = validator.validate(document);
+
+        // Mars + Fev + Jan = 3 consécutifs dans la fenêtre → PASSED
+        assertThat(output.isValid()).isTrue();
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
     }
 
     @Test

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNameMatchTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNameMatchTest.java
@@ -1,0 +1,322 @@
+package fr.dossierfacile.document.analysis.rule.validator.payslip;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.Guarantor;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.common.model.document_ia.ExtractionModel;
+import fr.dossierfacile.common.model.document_ia.GenericProperty;
+import fr.dossierfacile.common.model.document_ia.ResultModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayslipNameMatchTest {
+
+    private final PayslipNameMatch rule = new PayslipNameMatch();
+
+    // ==========================
+    // Helpers / Fixtures
+    // ==========================
+
+    private DocumentIAFileAnalysis analysisWithExtraction(String identiteSalarie) {
+        List<GenericProperty> props = new ArrayList<>();
+        if (identiteSalarie != null) {
+            props.add(GenericProperty.builder().name("identite_salarie").type("string").value(identiteSalarie).build());
+        }
+        ExtractionModel extraction = ExtractionModel.builder().type("bulletin_salaire").properties(props).build();
+        ResultModel result = ResultModel.builder().extraction(extraction).barcodes(List.of()).build();
+        return DocumentIAFileAnalysis.builder().analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS).result(result).build();
+    }
+
+    private DocumentIAFileAnalysis analysisWith2DDoc(String ligne1, String nom, String prenom) {
+        List<GenericProperty> beneficiaireProps = Stream.of(
+                ligne1  != null ? GenericProperty.builder().name("ligne1").type("string").value(ligne1).build() : null,
+                nom     != null ? GenericProperty.builder().name("nom").type("string").value(nom).build()       : null,
+                prenom  != null ? GenericProperty.builder().name("prenom").type("string").value(prenom).build() : null
+        ).filter(Objects::nonNull).toList();
+
+        GenericProperty beneficiaire = GenericProperty.builder()
+                .name("beneficiaire")
+                .type("object")
+                .value(beneficiaireProps)
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .type("2D_DOC")
+                .typedData(List.of(beneficiaire))
+                .build();
+
+        ResultModel result = ResultModel.builder().extraction(null).barcodes(List.of(barcode)).build();
+        return DocumentIAFileAnalysis.builder().analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS).result(result).build();
+    }
+
+    private DocumentIAFileAnalysis analysisWith2DDocAndExtraction(String ligne1, String identiteSalarie) {
+        List<GenericProperty> beneficiaireProps = List.of(
+                GenericProperty.builder().name("ligne1").type("string").value(ligne1).build()
+        );
+        GenericProperty beneficiaire = GenericProperty.builder()
+                .name("beneficiaire").type("object").value(beneficiaireProps).build();
+        BarcodeModel barcode = BarcodeModel.builder().type("2D_DOC").typedData(List.of(beneficiaire)).build();
+
+        ExtractionModel extraction = ExtractionModel.builder()
+                .type("bulletin_salaire")
+                .properties(List.of(GenericProperty.builder().name("identite_salarie").type("string").value(identiteSalarie).build()))
+                .build();
+
+        ResultModel result = ResultModel.builder().extraction(extraction).barcodes(List.of(barcode)).build();
+        return DocumentIAFileAnalysis.builder().analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS).result(result).build();
+    }
+
+    private DocumentIAFileAnalysis failedAnalysis() {
+        return DocumentIAFileAnalysis.builder().analysisStatus(DocumentIAFileAnalysisStatus.FAILED).build();
+    }
+
+    private Document documentWithTenant(String firstName, String lastName, DocumentIAFileAnalysis... analyses) {
+        Tenant tenant = Tenant.builder().firstName(firstName).lastName(lastName).build();
+        return buildDocument(tenant, null, analyses);
+    }
+
+    private Document documentWithGuarantor(String firstName, String lastName, DocumentIAFileAnalysis... analyses) {
+        Guarantor guarantor = Guarantor.builder().firstName(firstName).lastName(lastName).build();
+        return buildDocument(null, guarantor, analyses);
+    }
+
+    private Document buildDocument(Tenant tenant, Guarantor guarantor, DocumentIAFileAnalysis... analyses) {
+        List<File> files = Stream.of(analyses).map(analysis -> {
+            File file = File.builder().documentIAFileAnalysis(analysis).build();
+            if (analysis != null) analysis.setFile(file);
+            return file;
+        }).toList();
+
+        Document doc = Document.builder().files(files).tenant(tenant).guarantor(guarantor).build();
+        files.forEach(f -> f.setDocument(doc));
+        return doc;
+    }
+
+    // ==========================
+    // Tests — INCONCLUSIVE
+    // ==========================
+
+    @Test
+    @DisplayName("INCONCLUSIVE si aucune analyse disponible")
+    void inconclusive_when_no_analysis() {
+        Document doc = Document.builder().files(List.of())
+                .tenant(Tenant.builder().firstName("Jean").lastName("Dupont").build())
+                .build();
+
+        RuleValidatorOutput out = rule.validate(doc);
+
+        assertThat(out.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(out.rule().getRule()).isEqualTo(DocumentRule.R_PAYSLIP_NAME_MATCH);
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE si aucun tenant ni garant")
+    void inconclusive_when_no_tenant_no_guarantor() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("DUPONT JEAN");
+        Document doc = buildDocument(null, null, analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE si une analyse est en échec")
+    void inconclusive_when_any_analysis_failed() {
+        DocumentIAFileAnalysis success = analysisWithExtraction("DUPONT JEAN");
+        DocumentIAFileAnalysis failed = failedAnalysis();
+
+        Document doc = documentWithTenant("Jean", "Dupont", success, failed);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    @Test
+    @DisplayName("INCONCLUSIVE si identite_salarie est absent de l'extraction et pas de 2DDoc")
+    void inconclusive_when_identity_null_in_extraction_and_no_2ddoc() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction(null);
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    // ==========================
+    // Tests — PASSED via extraction
+    // ==========================
+
+    @Test
+    @DisplayName("PASSED avec identite_salarie contenant nom et prénom (extraction seule)")
+    void passed_with_extraction_identity() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR DUPONT JEAN");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        RuleValidatorOutput out = rule.validate(doc);
+
+        assertThat(out.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("PASSED avec extraction et tenant garant")
+    void passed_with_extraction_and_guarantor() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR MARTIN PAUL");
+        Document doc = documentWithGuarantor("Paul", "Martin", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    // ==========================
+    // Tests — PASSED via 2DDOC beneficiaire.ligne1
+    // ==========================
+
+    @Test
+    @DisplayName("PASSED avec 2DDOC beneficiaire.ligne1")
+    void passed_with_2ddoc_beneficiaire_ligne1() {
+        DocumentIAFileAnalysis analysis = analysisWith2DDoc("MR DUPONT JEAN", null, null);
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    // ==========================
+    // Tests — PASSED via 2DDOC beneficiaire.nom + prenom
+    // ==========================
+
+    @Test
+    @DisplayName("PASSED avec 2DDOC beneficiaire.nom + beneficiaire.prenom (ligne1 absent)")
+    void passed_with_2ddoc_beneficiaire_nom_and_prenom() {
+        DocumentIAFileAnalysis analysis = analysisWith2DDoc(null, "DUPONT", "JEAN");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("FAILED avec 2DDOC beneficiaire.nom seul (ligne1 et prenom absents) — le prénom est introuvable dans la chaîne")
+    void failed_with_2ddoc_beneficiaire_nom_only() {
+        DocumentIAFileAnalysis analysis = analysisWith2DDoc(null, "DUPONT", null);
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        // "Jean" n'est pas trouvé dans "DUPONT" → hasFirstNameMatch échoue → FAILED
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+
+    // ==========================
+    // Tests — priorité 2DDOC sur extraction
+    // ==========================
+
+    @Test
+    @DisplayName("2DDOC beneficiaire.ligne1 a priorité sur identite_salarie de l'extraction")
+    void twoDDoc_takes_priority_over_extraction() {
+        // 2DDOC dit "DUPONT JEAN" (correct), extraction dit "AUTRE PERSONNE" (incorrect si utilisée)
+        DocumentIAFileAnalysis analysis = analysisWith2DDocAndExtraction("MR DUPONT JEAN", "AUTRE PERSONNE");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("Fallback sur extraction quand aucun champ beneficiaire n'est renseigné dans le 2DDOC")
+    void fallback_to_extraction_when_2ddoc_beneficiaire_empty() {
+        // beneficiaire sans aucun champ renseigné
+        DocumentIAFileAnalysis analysis = analysisWith2DDocAndExtraction(null, "MR DUPONT JEAN");
+        // Dans ce cas, ligne1=null et tous les champs beneficiaire sont null →
+        // resolveIdentityString() retourne null → getIdentityString() retourne identiteString
+        // Mais ici on passe ligne1=null ce qui construit un barcode avec un beneficiaire vide.
+        // Le mapper ne trouvera rien de non-null dans BeneficiaireModel → fallback extraction.
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    // ==========================
+    // Tests — fuzzy matching
+    // ==========================
+
+    @Test
+    @DisplayName("PASSED avec accents normalisés dans l'identité extraite")
+    void passed_with_accents_normalized() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR MARTIN-BERNARD THEO");
+        Document doc = documentWithTenant("Théo", "Martin-Bernard", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("PASSED avec distance de Levenshtein ≤ 2 sur le nom")
+    void passed_with_levenshtein_distance_on_last_name() {
+        // "DUPOND" vs "DUPONT" → distance 1
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR DUPOND JEAN");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("PASSED avec nom composé et tiret dans l'extraction")
+    void passed_with_hyphenated_name_in_extraction() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR MARTIN BERNARD THEO");
+        Document doc = documentWithTenant("Théo", "Martin-Bernard", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    // ==========================
+    // Tests — FAILED
+    // ==========================
+
+    @Test
+    @DisplayName("FAILED si le nom dans l'extraction ne correspond pas")
+    void failed_when_last_name_does_not_match() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR MARTIN JEAN");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+
+    @Test
+    @DisplayName("FAILED si le prénom dans l'extraction ne correspond pas")
+    void failed_when_first_name_does_not_match() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR DUPONT PIERRE");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+
+    // ==========================
+    // Tests — multi-bulletins
+    // ==========================
+
+    @Test
+    @DisplayName("PASSED si tous les bulletins correspondent au même tenant")
+    void passed_when_all_payslips_match() {
+        DocumentIAFileAnalysis m1 = analysisWithExtraction("MR DUPONT JEAN");
+        DocumentIAFileAnalysis m2 = analysisWithExtraction("MR DUPONT JEAN");
+        DocumentIAFileAnalysis m3 = analysisWith2DDoc("MR DUPONT JEAN", null, null);
+
+        Document doc = documentWithTenant("Jean", "Dupont", m1, m2, m3);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("FAILED si un des bulletins ne correspond pas")
+    void failed_when_one_payslip_does_not_match() {
+        DocumentIAFileAnalysis match    = analysisWithExtraction("MR DUPONT JEAN");
+        DocumentIAFileAnalysis mismatch = analysisWithExtraction("MR MARTIN PIERRE");
+
+        Document doc = documentWithTenant("Jean", "Dupont", match, mismatch);
+
+        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
@@ -22,9 +22,9 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class PayslipNameMatchTest {
+class PayslipNamesRuleTest {
 
-    private final PayslipNameMatch rule = new PayslipNameMatch();
+    private final PayslipNamesRule rule = new PayslipNamesRule();
 
     // ==========================
     // Helpers / Fixtures


### PR DESCRIPTION
- Updated PayslipNameMatch to utilize IdentityMatchUtil for name matching logic.
- Introduced BeneficiaireModel to encapsulate beneficiary details.
- Refactored PayslipNames to include BeneficiaireModel and adjusted identity string resolution.
- Enhanced PayslipDate with additional extraction names for better mapping.
- Removed deprecated methods from TaxNamesRule and replaced them with IdentityMatchUtil methods for consistency.