### PR TITLE
feat(bo): assign operator to application

### DIFF
--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOApartmentSharingController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOApartmentSharingController.java
@@ -19,6 +19,8 @@ import fr.gouv.bo.dto.DisplayableFile;
 import fr.gouv.bo.dto.LinkLogDTO;
 import fr.gouv.bo.dto.MessageDTO;
 import fr.gouv.bo.dto.PartnerDTO;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.TenantLogService;
 import fr.gouv.bo.service.TenantService;
 import fr.gouv.bo.service.UserApiService;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -73,12 +76,15 @@ public class BOApartmentSharingController {
     private final TenantLogService logService;
     private final LinkLogRepository linkLogRepository;
     private final UserService userService;
+    private final BOApplicationAccessService applicationAccessService;
 
     @Value("${tenant.base.url}")
     private String tenantBaseUrl;
 
     @GetMapping("/{id}")
-    public String view(Model model, @PathVariable("id") Long id) {
+    public String view(Model model, @PathVariable("id") Long id,
+                       @AuthenticationPrincipal UserPrincipal principal) {
+        applicationAccessService.checkAndLogApartmentSharingAccess(principal, id);
 
         MessageDTO messageDTO = new MessageDTO();
         PartnerDTO partnerDTO = new PartnerDTO();

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOController.java
@@ -11,6 +11,8 @@ import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.gouv.bo.amqp.Producer;
 import fr.gouv.bo.dto.BooleanDTO;
 import fr.gouv.bo.dto.ReGroupDTO;
+import fr.gouv.bo.dto.ResultDTO;
+import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.DocumentService;
 import fr.gouv.bo.service.TenantService;
@@ -56,6 +58,7 @@ public class BOController {
     private final Producer producer;
     private final PartnerCallBackService partnerCallBackService;
     private final ClientRegistrationRepository clientRegistrationRepository;
+    private final BOApplicationAccessService applicationAccessService;
 
     @GetMapping("/")
     public String index(@AuthenticationPrincipal UserPrincipal principal) {
@@ -153,6 +156,7 @@ public class BOController {
     @PreAuthorize("hasRole('SUPPORT')")
     @GetMapping("/bo/searchTenant")
     public String searchTenant(Model model,
+                               @AuthenticationPrincipal UserPrincipal principal,
                                @RequestParam(value = EMAIL) String email,
                                @RequestParam(value = "page", defaultValue = "1") int page) {
 
@@ -161,6 +165,7 @@ public class BOController {
         
         PageRequest pageable = PageRequest.of(boundedPage - 1, pageSize, Sort.by("id").descending());
         Page<Tenant> tenants = tenantService.getTenantByIdOrEmail(email, pageable);
+        applicationAccessService.logSearchTenant(principal, email, tenants.getTotalElements());
 
         if (tenants.getTotalElements() == 1 && (email.contains("@") || StringUtils.isNumeric(email))) {
             return REDIRECT_BO_COLOCATION + tenants.getContent().getFirst().getApartmentSharing().getId();

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOMessageController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOMessageController.java
@@ -6,6 +6,7 @@ import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.entity.User;
 import fr.gouv.bo.dto.BrevoMailHistoryViewDTO;
 import fr.gouv.bo.dto.MessageDTO;
+import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.BrevoMailHistoryService;
 import fr.gouv.bo.service.MessageService;
@@ -36,6 +37,7 @@ public class BOMessageController {
     private final TenantService tenantService;
     private final MessageService messageService;
     private final UserService userService;
+    private final BOApplicationAccessService applicationAccessService;
     private final BrevoMailHistoryService brevoMailHistoryService;
 
     @GetMapping("/tenant/{id}")
@@ -44,7 +46,7 @@ public class BOMessageController {
             @PathVariable("id") Long id,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-
+        applicationAccessService.checkTenantAccess(principal, id);
         User tenant = tenantService.getUserById(id);
         Tenant tenant1 = tenantService.getTenantById(tenant.getId());
         ApartmentSharing apartmentSharing = tenant1.getApartmentSharing();

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
@@ -6,6 +6,7 @@ import fr.dossierfacile.common.exceptions.NotFoundException;
 import fr.dossierfacile.common.model.apartment_sharing.ApplicationModel;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.gouv.bo.dto.*;
+import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.*;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public class BOTenantController {
     private final UserService userService;
     private final TenantLogService logService;
     private final DocumentDeniedReasonsService documentDeniedReasonsService;
+    private final BOApplicationAccessService applicationAccessService;
 
     @GetMapping("/{id}")
     public String getTenant(@PathVariable Long id) {
@@ -162,7 +164,9 @@ public class BOTenantController {
     }
 
     @GetMapping("/{id}/processFile")
-    public String processFileForm(Model model, @PathVariable("id") Long id) {
+    public String processFileForm(Model model, @PathVariable("id") Long id,
+                                  @AuthenticationPrincipal UserPrincipal principal) {
+        applicationAccessService.checkTenantAccess(principal, id);
         Tenant tenant = tenantService.find(id);
 
         if (tenant == null) {

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/repository/OperatorLogRepository.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/repository/OperatorLogRepository.java
@@ -3,9 +3,34 @@ package fr.gouv.bo.repository;
 import fr.dossierfacile.common.entity.OperatorLog;
 import fr.dossierfacile.common.enums.ActionOperatorType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface OperatorLogRepository extends JpaRepository<OperatorLog, Long> {
+
     Long countByOperatorIdAndActionOperatorTypeAndCreationDateGreaterThanEqual(Long operatorId, ActionOperatorType actionType, LocalDateTime startDate);
+
+    boolean existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+            Long operatorId,
+            Long tenantId,
+            List<ActionOperatorType> types,
+            LocalDateTime since
+    );
+
+    @Query("""
+            SELECT COUNT(ol) > 0 FROM OperatorLog ol
+            WHERE ol.operator.id = :operatorId
+              AND ol.tenant.apartmentSharing.id = :apartmentSharingId
+              AND ol.actionOperatorType IN :types
+              AND ol.creationDate >= :since
+            """)
+    boolean existsAssignmentForApartmentSharing(
+            @Param("operatorId") Long operatorId,
+            @Param("apartmentSharingId") Long apartmentSharingId,
+            @Param("types") List<ActionOperatorType> types,
+            @Param("since") LocalDateTime since
+    );
 }

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
@@ -1,0 +1,21 @@
+package fr.gouv.bo.security;
+
+public interface BOApplicationAccessService {
+
+    /**
+     * Checks that the principal is authorised to view a dossier identified by tenantId.
+     * For OPERATOR: requires a START_PROCESS or STOP_PROCESS log for that tenant in the last 24 hours.
+     * For SUPPORT / MANAGER / ADMIN: always authorised.
+     * Throws AccessDeniedException if an OPERATOR is not assigned.
+     */
+    void checkTenantAccess(UserPrincipal principal, Long tenantId);
+
+    /**
+     * Checks that the principal is authorised to view a dossier identified by apartmentSharingId.
+     * For OPERATOR: requires a START_PROCESS or STOP_PROCESS log for any tenant of that apartment sharing in the last 24 hours.
+     * For SUPPORT / MANAGER / ADMIN: always authorised.
+     * Always writes a VIEW_APPLICATION entry to operator_log anchored to the CREATE tenant.
+     * Throws AccessDeniedException if an OPERATOR is not assigned.
+     */
+    void checkAndLogApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId);
+}

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
@@ -18,4 +18,9 @@ public interface BOApplicationAccessService {
      * Throws AccessDeniedException if an OPERATOR is not assigned.
      */
     void checkAndLogApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId);
+
+    /**
+     * Logs a tenant search action performed from BO search endpoints.
+     */
+    void logSearchTenant(UserPrincipal principal, String query, long resultCount);
 }

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
@@ -1,5 +1,7 @@
 package fr.gouv.bo.security;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.dossierfacile.common.entity.OperatorLog;
 import fr.dossierfacile.common.entity.User;
 import fr.dossierfacile.common.enums.ActionOperatorType;
@@ -9,6 +11,7 @@ import fr.gouv.bo.repository.OperatorLogRepository;
 import fr.gouv.bo.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
@@ -60,6 +63,25 @@ public class BOApplicationAccessServiceImpl implements BOApplicationAccessServic
         logViewApplicationForApartmentSharing(principal, apartmentSharingId);
     }
 
+    @Override
+    public void logSearchTenant(UserPrincipal principal, String query, long resultCount) {
+        User operator = userService.findUserByEmail(principal.getEmail());
+
+        ObjectNode metadata = JsonNodeFactory.instance.objectNode();
+        String normalizedQuery = StringUtils.trimToEmpty(query);
+        metadata.put("searchType", detectSearchType(normalizedQuery));
+        metadata.put("query", normalizedQuery);
+        metadata.put("resultCount", resultCount);
+
+        operatorLogRepository.save(new OperatorLog(
+                null,
+                operator,
+                null,
+                ActionOperatorType.SEARCH_TENANT,
+                metadata
+        ));
+    }
+
     /**
      * Returns true when the authenticated user holds ROLE_OPERATOR but none of
      * ROLE_SUPPORT / ROLE_MANAGER / ROLE_ADMIN.
@@ -86,5 +108,15 @@ public class BOApplicationAccessServiceImpl implements BOApplicationAccessServic
                     operatorLogRepository.save(
                             new OperatorLog(tenant, operator, tenant.getStatus(), ActionOperatorType.VIEW_APPLICATION));
                 });
+    }
+
+    private String detectSearchType(String query) {
+        if (StringUtils.contains(query, "@")) {
+            return "EMAIL";
+        }
+        if (StringUtils.isNumeric(query)) {
+            return "TENANT_ID";
+        }
+        return "TEXT";
     }
 }

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
@@ -1,0 +1,90 @@
+package fr.gouv.bo.security;
+
+import fr.dossierfacile.common.entity.OperatorLog;
+import fr.dossierfacile.common.entity.User;
+import fr.dossierfacile.common.enums.ActionOperatorType;
+import fr.dossierfacile.common.enums.TenantType;
+import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.gouv.bo.repository.OperatorLogRepository;
+import fr.gouv.bo.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BOApplicationAccessServiceImpl implements BOApplicationAccessService {
+
+    private static final List<ActionOperatorType> ASSIGNMENT_TYPES =
+            List.of(ActionOperatorType.START_PROCESS, ActionOperatorType.STOP_PROCESS);
+
+    private final OperatorLogRepository operatorLogRepository;
+    private final TenantCommonRepository tenantRepository;
+    private final UserService userService;
+
+    @Override
+    public void checkTenantAccess(UserPrincipal principal, Long tenantId) {
+        if (isOperatorOnly(principal)) {
+            LocalDateTime since = LocalDateTime.now().minusHours(24);
+            boolean assigned = operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            principal.getId(), tenantId, ASSIGNMENT_TYPES, since);
+            if (!assigned) {
+                log.warn("OPERATOR id={} attempted to access unassigned tenant id={}", principal.getId(), tenantId);
+                throw new AccessDeniedException(
+                        "OPERATOR " + principal.getId() + " is not assigned to tenant " + tenantId);
+            }
+        }
+    }
+
+    @Override
+    public void checkAndLogApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId) {
+        if (isOperatorOnly(principal)) {
+            LocalDateTime since = LocalDateTime.now().minusHours(24);
+            boolean assigned = operatorLogRepository.existsAssignmentForApartmentSharing(
+                    principal.getId(), apartmentSharingId, ASSIGNMENT_TYPES, since);
+            if (!assigned) {
+                log.warn("OPERATOR id={} attempted to access unassigned apartment sharing id={}", principal.getId(), apartmentSharingId);
+                throw new AccessDeniedException(
+                        "OPERATOR " + principal.getId() + " is not assigned to apartment sharing " + apartmentSharingId);
+            }
+        }
+        logViewApplicationForApartmentSharing(principal, apartmentSharingId);
+    }
+
+    /**
+     * Returns true when the authenticated user holds ROLE_OPERATOR but none of
+     * ROLE_SUPPORT / ROLE_MANAGER / ROLE_ADMIN.
+     * Checks explicit authorities only (not hierarchy-derived ones): CustomOidcUserService
+     * adds only the explicitly granted UserRole entries as SimpleGrantedAuthority, so a
+     * ROLE_ADMIN user never has ROLE_OPERATOR in their authority set.
+     */
+    private boolean isOperatorOnly(UserPrincipal principal) {
+        Set<String> authorities = principal.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toSet());
+        return authorities.contains("ROLE_OPERATOR")
+                && !authorities.contains("ROLE_SUPPORT")
+                && !authorities.contains("ROLE_MANAGER")
+                && !authorities.contains("ROLE_ADMIN");
+    }
+
+    private void logViewApplicationForApartmentSharing(UserPrincipal principal, Long apartmentSharingId) {
+        tenantRepository.findAllByApartmentSharingId(apartmentSharingId).stream()
+                .filter(t -> t.getTenantType() == TenantType.CREATE)
+                .findFirst()
+                .ifPresent(tenant -> {
+                    User operator = userService.findUserByEmail(principal.getEmail());
+                    operatorLogRepository.save(
+                            new OperatorLog(tenant, operator, tenant.getStatus(), ActionOperatorType.VIEW_APPLICATION));
+                });
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOApartmentSharingControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOApartmentSharingControllerTest.java
@@ -8,22 +8,33 @@ import fr.dossierfacile.common.enums.LinkType;
 import fr.dossierfacile.common.repository.LinkLogRepository;
 import fr.gouv.bo.dto.ApartmentSharingLinkEnrichedDTO;
 import fr.gouv.bo.dto.LinkLogDTO;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.UserApiService;
 import fr.gouv.bo.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.ExtendedModelMap;
 
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,12 +49,15 @@ class BOApartmentSharingControllerTest {
     @Mock
     private UserApiService userApiService;
 
+    @Mock
+    private BOApplicationAccessService applicationAccessService;
+
     private BOApartmentSharingController controller;
 
     @BeforeEach
     void setUp() {
         controller = new BOApartmentSharingController(
-                null, null, userApiService, null, linkLogRepository, userService
+                null, null, userApiService, null, linkLogRepository, userService, applicationAccessService
         );
         ReflectionTestUtils.setField(controller, "tenantBaseUrl", "https://example.com");
     }
@@ -113,5 +127,52 @@ class BOApartmentSharingControllerTest {
         Method method = BOApartmentSharingController.class.getDeclaredMethod("enrichApartmentSharingLinks", List.class);
         method.setAccessible(true);
         return (List<ApartmentSharingLinkEnrichedDTO>) method.invoke(controller, links);
+    }
+
+    // -------------------------------------------------------------------------
+    // view() — access control
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class ViewEndpoint {
+
+        private static final Long APARTMENT_SHARING_ID = 99L;
+
+        @Test
+        void view_whenAccessServiceThrowsAccessDenied_propagatesException() {
+            UserPrincipal principal = operatorPrincipal();
+            doThrow(new AccessDeniedException("forbidden"))
+                    .when(applicationAccessService)
+                    .checkAndLogApartmentSharingAccess(any(), eq(APARTMENT_SHARING_ID));
+
+            assertThatThrownBy(() -> controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage("forbidden");
+        }
+
+        @Test
+        void view_callsAccessServiceWithCorrectArguments() {
+            UserPrincipal principal = supportPrincipal();
+            // Access service does nothing (no exception) — let the controller proceed;
+            // it will NPE on tenantService (null) after the access check, which is acceptable
+            // here since the goal is only to assert the access check is invoked first.
+            try {
+                controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal);
+            } catch (Exception ignored) {
+                // Expected: method continues past the access check but fails on null tenantService
+            }
+
+            verify(applicationAccessService).checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+        }
+    }
+
+    private UserPrincipal operatorPrincipal() {
+        return new UserPrincipal(10L, "operator", "operator@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+    }
+
+    private UserPrincipal supportPrincipal() {
+        return new UserPrincipal(20L, "support", "support@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_SUPPORT")));
     }
 }

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOControllerSearchTenantTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOControllerSearchTenantTest.java
@@ -52,7 +52,7 @@ class BOControllerSearchTenantTest {
         Page<Tenant> page = new PageImpl<>(List.of(tenant), PageRequest.of(0, 20), 1);
         when(tenantService.getTenantByIdOrEmail(eq("john.doe@example.com"), any(PageRequest.class))).thenReturn(page);
 
-        String view = controller.searchTenant(new ExtendedModelMap(), principal, "john.doe@example.com", 20, 1);
+        String view = controller.searchTenant(new ExtendedModelMap(), principal, "john.doe@example.com", 1);
 
         assertThat(view).isEqualTo("redirect:/bo/colocation/99");
         verify(applicationAccessService).logSearchTenant(principal, "john.doe@example.com", 1L);
@@ -64,7 +64,7 @@ class BOControllerSearchTenantTest {
         Page<Tenant> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
         when(tenantService.getTenantByIdOrEmail(eq("nobody@example.com"), any(PageRequest.class))).thenReturn(page);
 
-        String view = controller.searchTenant(new ExtendedModelMap(), principal, "nobody@example.com", 20, 1);
+        String view = controller.searchTenant(new ExtendedModelMap(), principal, "nobody@example.com", 1);
 
         assertThat(view).isEqualTo("bo/search");
         verify(applicationAccessService).logSearchTenant(principal, "nobody@example.com", 0L);

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOControllerSearchTenantTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOControllerSearchTenantTest.java
@@ -1,0 +1,91 @@
+package fr.gouv.bo.controller;
+
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.TenantType;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
+import fr.gouv.bo.service.TenantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.ui.ExtendedModelMap;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BOControllerSearchTenantTest {
+
+    private TenantService tenantService;
+    private BOApplicationAccessService applicationAccessService;
+    private BOController controller;
+
+    @BeforeEach
+    void setUp() {
+        tenantService = mock(TenantService.class);
+        applicationAccessService = mock(BOApplicationAccessService.class);
+        controller = new BOController(
+                tenantService,
+                null,
+                null,
+                null,
+                null,
+                null,
+                applicationAccessService
+        );
+    }
+
+    @Test
+    void searchTenant_logsSearchAndRedirectsWhenSingleEmailMatch() {
+        UserPrincipal principal = supportPrincipal();
+        Tenant tenant = tenant(42L, 99L);
+        Page<Tenant> page = new PageImpl<>(List.of(tenant), PageRequest.of(0, 20), 1);
+        when(tenantService.getTenantByIdOrEmail(eq("john.doe@example.com"), any(PageRequest.class))).thenReturn(page);
+
+        String view = controller.searchTenant(new ExtendedModelMap(), principal, "john.doe@example.com", 20, 1);
+
+        assertThat(view).isEqualTo("redirect:/bo/colocation/99");
+        verify(applicationAccessService).logSearchTenant(principal, "john.doe@example.com", 1L);
+    }
+
+    @Test
+    void searchTenant_logsSearchWithNullAnchorWhenNoResult() {
+        UserPrincipal principal = supportPrincipal();
+        Page<Tenant> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+        when(tenantService.getTenantByIdOrEmail(eq("nobody@example.com"), any(PageRequest.class))).thenReturn(page);
+
+        String view = controller.searchTenant(new ExtendedModelMap(), principal, "nobody@example.com", 20, 1);
+
+        assertThat(view).isEqualTo("bo/search");
+        verify(applicationAccessService).logSearchTenant(principal, "nobody@example.com", 0L);
+    }
+
+    private Tenant tenant(Long tenantId, Long apartmentSharingId) {
+        Tenant tenant = new Tenant();
+        tenant.setId(tenantId);
+        tenant.setTenantType(TenantType.CREATE);
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setId(apartmentSharingId);
+        tenant.setApartmentSharing(apartmentSharing);
+        return tenant;
+    }
+
+    private UserPrincipal supportPrincipal() {
+        return new UserPrincipal(
+                20L,
+                "support",
+                "support@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_SUPPORT"))
+        );
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
@@ -5,6 +5,7 @@ import fr.dossierfacile.common.entity.BOUser;
 import fr.dossierfacile.common.entity.Message;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.gouv.bo.dto.BrevoMailHistoryViewDTO;
+import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.BrevoMailHistoryService;
 import fr.gouv.bo.service.MessageService;
@@ -29,6 +30,7 @@ class BOMessageControllerTest {
     private TenantService tenantService;
     private MessageService messageService;
     private UserService userService;
+    private BOApplicationAccessService applicationAccessService;
     private BrevoMailHistoryService brevoMailHistoryService;
     private BOMessageController controller;
 
@@ -37,11 +39,13 @@ class BOMessageControllerTest {
         tenantService = mock(TenantService.class);
         messageService = mock(MessageService.class);
         userService = mock(UserService.class);
+        applicationAccessService = mock(BOApplicationAccessService.class);
         brevoMailHistoryService = mock(BrevoMailHistoryService.class);
         controller = new BOMessageController(
                 tenantService,
                 messageService,
                 userService,
+                applicationAccessService,
                 brevoMailHistoryService
         );
     }

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
@@ -7,6 +7,7 @@ import fr.dossierfacile.common.repository.LinkLogRepository;
 import fr.dossierfacile.common.service.ApartmentSharingLinkService;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.gouv.bo.TestBOApplication;
+import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.service.*;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -83,6 +84,8 @@ class TaxDisplayTest {
     private TenantLogService logService;
     @MockitoBean
     private DocumentDeniedReasonsService documentDeniedReasonsService;
+    @MockitoBean
+    private BOApplicationAccessService applicationAccessService;
 
     // BOApartmentSharingController dependencies
     @MockitoBean

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
@@ -258,6 +258,46 @@ class BOApplicationAccessServiceTest {
         }
     }
 
+    @Nested
+    class LogSearchTenant {
+
+        @Test
+        void logSearchTenant_logsExpectedMetadata() {
+            UserPrincipal principal = supportPrincipal();
+
+            service.logSearchTenant(principal, "john.doe@example.com", 2L);
+
+            ArgumentCaptor<OperatorLog> captor = ArgumentCaptor.forClass(OperatorLog.class);
+            verify(operatorLogRepository).save(captor.capture());
+            OperatorLog log = captor.getValue();
+
+            assertThat(log.getActionOperatorType()).isEqualTo(ActionOperatorType.SEARCH_TENANT);
+            assertThat(log.getTenant()).isNull();
+            assertThat(log.getTenantFileStatus()).isNull();
+            assertThat(log.getMetadata().get("searchType").asText()).isEqualTo("EMAIL");
+            assertThat(log.getMetadata().get("query").asText()).isEqualTo("john.doe@example.com");
+            assertThat(log.getMetadata().get("resultCount").asLong()).isEqualTo(2L);
+        }
+
+        @Test
+        void logSearchTenant_withoutAnchorTenant_logsWithNullTenant() {
+            UserPrincipal principal = supportPrincipal();
+
+            service.logSearchTenant(principal, "unknown@example.com", 0L);
+
+            ArgumentCaptor<OperatorLog> captor = ArgumentCaptor.forClass(OperatorLog.class);
+            verify(operatorLogRepository).save(captor.capture());
+            OperatorLog log = captor.getValue();
+
+            assertThat(log.getActionOperatorType()).isEqualTo(ActionOperatorType.SEARCH_TENANT);
+            assertThat(log.getTenant()).isNull();
+            assertThat(log.getTenantFileStatus()).isNull();
+            assertThat(log.getMetadata().get("searchType").asText()).isEqualTo("EMAIL");
+            assertThat(log.getMetadata().get("query").asText()).isEqualTo("unknown@example.com");
+            assertThat(log.getMetadata().get("resultCount").asLong()).isEqualTo(0L);
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
@@ -1,0 +1,305 @@
+package fr.gouv.bo.security;
+
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.BOUser;
+import fr.dossierfacile.common.entity.OperatorLog;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.ActionOperatorType;
+import fr.dossierfacile.common.enums.TenantFileStatus;
+import fr.dossierfacile.common.enums.TenantType;
+import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.gouv.bo.repository.OperatorLogRepository;
+import fr.gouv.bo.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static fr.dossierfacile.common.enums.ActionOperatorType.START_PROCESS;
+import static fr.dossierfacile.common.enums.ActionOperatorType.STOP_PROCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BOApplicationAccessServiceTest {
+
+    private static final Long OPERATOR_ID = 10L;
+    private static final Long TENANT_ID = 42L;
+    private static final Long APARTMENT_SHARING_ID = 100L;
+
+    private OperatorLogRepository operatorLogRepository;
+    private TenantCommonRepository tenantRepository;
+    private UserService userService;
+
+    private BOApplicationAccessServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        operatorLogRepository = mock(OperatorLogRepository.class);
+        tenantRepository = mock(TenantCommonRepository.class);
+        userService = mock(UserService.class);
+        service = new BOApplicationAccessServiceImpl(operatorLogRepository, tenantRepository, userService);
+
+        // Default: tenant and operator exist
+        Tenant tenant = buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID);
+        when(tenantRepository.findOneById(TENANT_ID)).thenReturn(tenant);
+        when(tenantRepository.findAllByApartmentSharingId(APARTMENT_SHARING_ID)).thenReturn(List.of(tenant));
+        when(userService.findUserByEmail(any())).thenReturn(new BOUser());
+    }
+
+    // -------------------------------------------------------------------------
+    // checkTenantAccess
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CheckAndLogTenantAccess {
+
+        @Test
+        void operator_withStartProcessToday_isAuthorized() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkTenantAccess(principal, TENANT_ID);
+            verifyNoLogWritten();
+        }
+
+        @Test
+        void operator_withStopProcessToday_isAuthorized() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkTenantAccess(principal, TENANT_ID);
+            verifyNoLogWritten();
+        }
+
+        @Test
+        void operator_withNoAssignment_throwsAccessDeniedAndNothingLogged() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.checkTenantAccess(principal, TENANT_ID))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void operator_withAssignmentYesterday_throwsAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            // existsByOperatorId... returns false regardless of the date passed
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.checkTenantAccess(principal, TENANT_ID))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void support_isAlwaysAuthorized() {
+            service.checkTenantAccess(supportPrincipal(), TENANT_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any());
+            verifyNoLogWritten();
+        }
+
+        @Test
+        void manager_isAlwaysAuthorized() {
+            service.checkTenantAccess(managerPrincipal(), TENANT_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any());
+            verifyNoLogWritten();
+        }
+
+        @Test
+        void admin_isAlwaysAuthorized() {
+            service.checkTenantAccess(adminPrincipal(), TENANT_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any());
+            verifyNoLogWritten();
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        // Vérifie que le contrôle d'assignation utilise uniquement START_PROCESS et STOP_PROCESS.
+        void assignmentCheck_passesStartAndStopProcessTypes() {
+            UserPrincipal principal = operatorPrincipal();
+            ArgumentCaptor<List<ActionOperatorType>> typesCaptor = ArgumentCaptor.forClass(List.class);
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), typesCaptor.capture(), any()))
+                    .thenReturn(true);
+
+            service.checkTenantAccess(principal, TENANT_ID);
+
+            assertThat(typesCaptor.getValue()).containsExactlyInAnyOrder(START_PROCESS, STOP_PROCESS);
+        }
+
+        @Test
+        // Vérifie que la fenêtre temporelle transmise au repository est bien "maintenant - 24h".
+        void assignmentCheck_sinceLast24Hours() {
+            UserPrincipal principal = operatorPrincipal();
+            ArgumentCaptor<LocalDateTime> sinceCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+            LocalDateTime beforeCall = LocalDateTime.now().minusHours(24);
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), sinceCaptor.capture()))
+                    .thenReturn(true);
+
+            service.checkTenantAccess(principal, TENANT_ID);
+            LocalDateTime afterCall = LocalDateTime.now().minusHours(24);
+
+            LocalDateTime since = sinceCaptor.getValue();
+            assertThat(since).isBetween(beforeCall.minusSeconds(1), afterCall.plusSeconds(1));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // checkAndLogApartmentSharingAccess
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CheckAndLogApartmentSharingAccess {
+
+        @Test
+        void operator_withAssignmentForTenantInSharing_isAuthorizedAndLogged() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository.existsAssignmentForApartmentSharing(
+                    eq(OPERATOR_ID), eq(APARTMENT_SHARING_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+
+            verifyViewApplicationLoggedForApartmentSharing();
+        }
+
+        @Test
+        void operator_withNoAssignmentInSharing_throwsAccessDeniedAndNothingLogged() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository.existsAssignmentForApartmentSharing(
+                    anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID))
+                    .isInstanceOf(AccessDeniedException.class);
+
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void support_isAlwaysAuthorizedAndLogged() {
+            service.checkAndLogApartmentSharingAccess(supportPrincipal(), APARTMENT_SHARING_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsAssignmentForApartmentSharing(anyLong(), anyLong(), anyList(), any());
+            verifyViewApplicationLoggedForApartmentSharing();
+        }
+
+        @Test
+        void manager_isAlwaysAuthorizedAndLogged() {
+            service.checkAndLogApartmentSharingAccess(managerPrincipal(), APARTMENT_SHARING_ID);
+
+            verifyViewApplicationLoggedForApartmentSharing();
+        }
+
+        @Test
+        void admin_isAlwaysAuthorizedAndLogged() {
+            service.checkAndLogApartmentSharingAccess(adminPrincipal(), APARTMENT_SHARING_ID);
+
+            verifyViewApplicationLoggedForApartmentSharing();
+        }
+
+        @Test
+        // Vérifie que le log VIEW_APPLICATION sur la vue colocation est rattaché au tenant CREATE.
+        void log_isAnchoredToCreateTenant() {
+            UserPrincipal principal = supportPrincipal();
+            Tenant createTenant = buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID);
+            Tenant joinTenant = buildTenant(99L, TenantType.JOIN, APARTMENT_SHARING_ID);
+            when(tenantRepository.findAllByApartmentSharingId(APARTMENT_SHARING_ID))
+                    .thenReturn(List.of(joinTenant, createTenant));
+
+            service.checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+
+            ArgumentCaptor<OperatorLog> logCaptor = ArgumentCaptor.forClass(OperatorLog.class);
+            verify(operatorLogRepository).save(logCaptor.capture());
+            assertThat(logCaptor.getValue().getTenant()).isSameAs(createTenant);
+            assertThat(logCaptor.getValue().getActionOperatorType()).isEqualTo(ActionOperatorType.VIEW_APPLICATION);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void verifyNoLogWritten() {
+        verify(operatorLogRepository, never()).save(any());
+    }
+
+    private void verifyViewApplicationLoggedForApartmentSharing() {
+        ArgumentCaptor<OperatorLog> captor = ArgumentCaptor.forClass(OperatorLog.class);
+        verify(operatorLogRepository).save(captor.capture());
+        assertThat(captor.getValue().getActionOperatorType()).isEqualTo(ActionOperatorType.VIEW_APPLICATION);
+    }
+
+    private UserPrincipal operatorPrincipal() {
+        return new UserPrincipal(OPERATOR_ID, "operator", "operator@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+    }
+
+    private UserPrincipal supportPrincipal() {
+        return new UserPrincipal(20L, "support", "support@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_SUPPORT")));
+    }
+
+    private UserPrincipal managerPrincipal() {
+        return new UserPrincipal(21L, "manager", "manager@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_MANAGER")));
+    }
+
+    private UserPrincipal adminPrincipal() {
+        return new UserPrincipal(22L, "admin", "admin@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+    }
+
+    private Tenant buildTenant(Long id, TenantType type, Long apartmentSharingId) {
+        Tenant tenant = new Tenant();
+        tenant.setId(id);
+        tenant.setTenantType(type);
+        tenant.setStatus(TenantFileStatus.TO_PROCESS);
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setId(apartmentSharingId);
+        tenant.setApartmentSharing(apartmentSharing);
+        return tenant;
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -72,7 +73,9 @@ class BOApplicationAccessServiceTest {
             UserPrincipal principal = operatorPrincipal();
             when(operatorLogRepository
                     .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
-                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                        eq(OPERATOR_ID), eq(TENANT_ID),
+                        argThat(types -> types.contains(START_PROCESS)),
+                        any(LocalDateTime.class)))
                     .thenReturn(true);
 
             service.checkTenantAccess(principal, TENANT_ID);
@@ -84,7 +87,9 @@ class BOApplicationAccessServiceTest {
             UserPrincipal principal = operatorPrincipal();
             when(operatorLogRepository
                     .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
-                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                            eq(OPERATOR_ID), eq(TENANT_ID),
+                            argThat(types -> types.contains(STOP_PROCESS)),
+                            any(LocalDateTime.class)))
                     .thenReturn(true);
 
             service.checkTenantAccess(principal, TENANT_ID);
@@ -294,7 +299,7 @@ class BOApplicationAccessServiceTest {
             assertThat(log.getTenantFileStatus()).isNull();
             assertThat(log.getMetadata().get("searchType").asText()).isEqualTo("EMAIL");
             assertThat(log.getMetadata().get("query").asText()).isEqualTo("unknown@example.com");
-            assertThat(log.getMetadata().get("resultCount").asLong()).isEqualTo(0L);
+            assertThat(log.getMetadata().get("resultCount").asLong()).isZero();
         }
     }
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/OperatorLog.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/OperatorLog.java
@@ -1,5 +1,6 @@
 package fr.dossierfacile.common.entity;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fr.dossierfacile.common.enums.ActionOperatorType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import jakarta.persistence.Column;
@@ -17,6 +18,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 
@@ -58,6 +61,10 @@ public class OperatorLog {
     @Column(name = "time_spent")
     private Integer timeSpent;
 
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb")
+    private ObjectNode metadata;
+
     public OperatorLog(Tenant tenant, User operator, TenantFileStatus tenantFileStatus, ActionOperatorType actionOperatorType, Integer processedDocuments, Integer timeSpent) {
         this.tenant = tenant;
         this.operator = operator;
@@ -70,6 +77,11 @@ public class OperatorLog {
 
     public OperatorLog(Tenant tenant, User operator, TenantFileStatus tenantFileStatus, ActionOperatorType actionOperatorType) {
         this(tenant, operator, tenantFileStatus, actionOperatorType, null, null);
+    }
+
+    public OperatorLog(Tenant tenant, User operator, TenantFileStatus tenantFileStatus, ActionOperatorType actionOperatorType, ObjectNode metadata) {
+        this(tenant, operator, tenantFileStatus, actionOperatorType, null, null);
+        this.metadata = metadata;
     }
 
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/ActionOperatorType.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/ActionOperatorType.java
@@ -4,4 +4,5 @@ public enum ActionOperatorType {
     START_PROCESS,
     STOP_PROCESS,
     VIEW_APPLICATION,
+    SEARCH_TENANT,
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/ActionOperatorType.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/ActionOperatorType.java
@@ -3,4 +3,5 @@ package fr.dossierfacile.common.enums;
 public enum ActionOperatorType {
     START_PROCESS,
     STOP_PROCESS,
+    VIEW_APPLICATION,
 }

--- a/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
+++ b/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
@@ -187,4 +187,5 @@
     <include file="db/migration/202603090000-insert-document-ia-feature-flagging.xml" />
     <include file="db/migration/202603300000-add-document-ia-salary-more-3-months-feature-flag.xml" />
     <include file="db/migration/202603180000-drop-column-exclusive-partner-id-bouser.xml" />
+    <include file="db/migration/202604080000-add-search-tenant-metadata-operator-log.xml" />
 </databaseChangeLog>

--- a/dossierfacile-common-library/src/main/resources/db/migration/202604080000-add-search-tenant-metadata-operator-log.xml
+++ b/dossierfacile-common-library/src/main/resources/db/migration/202604080000-add-search-tenant-metadata-operator-log.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet id="202604080000" author="cursor">
+        <addColumn tableName="operator_log">
+            <column name="metadata" type="jsonb"/>
+        </addColumn>
+
+        <dropNotNullConstraint
+                tableName="operator_log"
+                columnName="tenant_id"
+                columnDataType="bigint"/>
+
+        <dropNotNullConstraint
+                tableName="operator_log"
+                columnName="tenant_status"
+                columnDataType="varchar"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dossierfacile-common-library/src/main/resources/db/migration/202604080000-add-search-tenant-metadata-operator-log.xml
+++ b/dossierfacile-common-library/src/main/resources/db/migration/202604080000-add-search-tenant-metadata-operator-log.xml
@@ -2,7 +2,7 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
-    <changeSet id="202604080000" author="cursor">
+    <changeSet id="202604080000" author="Romaric">
         <addColumn tableName="operator_log">
             <column name="metadata" type="jsonb"/>
         </addColumn>
@@ -16,5 +16,17 @@ http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
                 tableName="operator_log"
                 columnName="tenant_status"
                 columnDataType="varchar"/>
+
+        <rollback>
+            <addNotNullConstraint
+                    tableName="operator_log"
+                    columnName="tenant_status"
+                    columnDataType="varchar"/>
+            <addNotNullConstraint
+                    tableName="operator_log"
+                    columnName="tenant_id"
+                    columnDataType="bigint"/>
+            <dropColumn tableName="operator_log" columnName="metadata"/>
+        </rollback>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Use already existing table `operator_log` to :
- log access to tenant application page `VIEW_APPLICATION`
- log search action with `SEARCH_TENANT`
- implement a permission access based on `START_PROCESS` for `OPERATOR` role

Next PR will add action limits for all operator roles (`OPERATOR`, `SUPPORT`...) with a refactored QuotaService