### PR TITLE
feature(document-ia): rework payslip rule data

### DIFF
--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipClassificationRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipClassificationRuleData.java
@@ -1,0 +1,23 @@
+package fr.dossierfacile.common.entity.rule;
+
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+public record PayslipClassificationRuleData(List<PayslipClassificationEntry> entriesInError, List<YearMonth> expectedMonths) implements RuleData {
+
+    public PayslipClassificationRuleData addItem(PayslipClassificationEntry entry) {
+        List<PayslipClassificationEntry> newList = new ArrayList<>(this.entriesInError);
+        newList.add(entry);
+        return new PayslipClassificationRuleData(newList, expectedMonths);
+    }
+
+    @Override
+    public String getType() {
+        return R_PAYSLIP_CLASSIFICATION;
+    }
+
+    public record PayslipClassificationEntry(Long fileId, String fileName) {
+    }
+}
+

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipContinuityRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipContinuityRuleData.java
@@ -6,18 +6,18 @@ import java.util.List;
 
 public record PayslipContinuityRuleData(
         List<YearMonth> expectedMonthList,
-        List<PayslipContinuityEntry> payslipContinuityEntries,
+        List<PayslipContinuityEntry> payslipEntriesInError,
         List<YearMonth> missingMonthList
 ) implements RuleData {
 
-    public PayslipContinuityRuleData addItem(PayslipContinuityEntry payslipContinuityEntry) {
-        List<PayslipContinuityEntry> newList = new ArrayList<>(this.payslipContinuityEntries);
-        newList.add(payslipContinuityEntry);
+    public PayslipContinuityRuleData addItem(PayslipContinuityEntry errorEntry) {
+        List<PayslipContinuityEntry> newList = new ArrayList<>(this.payslipEntriesInError);
+        newList.add(errorEntry);
         return new PayslipContinuityRuleData(this.expectedMonthList, newList, this.missingMonthList);
     }
 
     public PayslipContinuityRuleData withMissingMonthList(List<YearMonth> missingMonthList) {
-        return new PayslipContinuityRuleData(this.expectedMonthList, this.payslipContinuityEntries, missingMonthList);
+        return new PayslipContinuityRuleData(this.expectedMonthList, this.payslipEntriesInError, missingMonthList);
     }
 
     @Override

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipContinuityRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipContinuityRuleData.java
@@ -1,16 +1,30 @@
 package fr.dossierfacile.common.entity.rule;
 
 import java.time.YearMonth;
+import java.util.ArrayList;
 import java.util.List;
 
-public record PayslipContinuityRuleData(List<YearMonth> expectedMonthList, List<YearMonth> extractedMonthList) implements RuleData {
+public record PayslipContinuityRuleData(
+        List<YearMonth> expectedMonthList,
+        List<PayslipContinuityEntry> payslipContinuityEntries,
+        List<YearMonth> missingMonthList
+) implements RuleData {
 
-    public PayslipContinuityRuleData(PayslipContinuityRuleData other, List<YearMonth> extractedMonthList) {
-        this(other.expectedMonthList, List.copyOf(extractedMonthList));
+    public PayslipContinuityRuleData addItem(PayslipContinuityEntry payslipContinuityEntry) {
+        List<PayslipContinuityEntry> newList = new ArrayList<>(this.payslipContinuityEntries);
+        newList.add(payslipContinuityEntry);
+        return new PayslipContinuityRuleData(this.expectedMonthList, newList, this.missingMonthList);
+    }
+
+    public PayslipContinuityRuleData withMissingMonthList(List<YearMonth> missingMonthList) {
+        return new PayslipContinuityRuleData(this.expectedMonthList, this.payslipContinuityEntries, missingMonthList);
     }
 
     @Override
     public String getType() {
         return R_PAYSLIP_CONTINUITY;
+    }
+
+    public record PayslipContinuityEntry(Long fileId, String fileName, YearMonth extractedMonth) {
     }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
@@ -1,16 +1,27 @@
 package fr.dossierfacile.common.entity.rule;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public record PayslipNamesRuleData(Name expectedName, List<String> extractedIdentities) implements RuleData {
-   public PayslipNamesRuleData(PayslipNamesRuleData other, List<String> extractedIdentities) {
-      this(other.expectedName, List.copyOf(extractedIdentities));
-   }
+public record PayslipNamesRuleData(Name expectedName, List<PayslipNamesEntry> payslipNamesEntryList) implements RuleData {
 
-   public String getType() {
-      return R_PAYSLIP_NAMES;
-   }
+    public PayslipNamesRuleData addItem(PayslipNamesEntry payslipNamesEntry) {
+        List<PayslipNamesEntry> newList = new ArrayList<>(this.payslipNamesEntryList);
+        newList.add(payslipNamesEntry);
+        return new PayslipNamesRuleData(this.expectedName, newList);
+    }
 
-   public static record Name(String firstNames, String lastName, String preferredName) {
-   }
+    public String getType() {
+        return R_PAYSLIP_NAMES;
+    }
+
+    public record Name(String firstNames, String lastName, String preferredName) {
+    }
+
+    public record PayslipNamesEntry(
+            Long fileId,
+            String fileName,
+            String ExtractedName
+    ) {
+    }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/PayslipNamesRuleData.java
@@ -3,11 +3,14 @@ package fr.dossierfacile.common.entity.rule;
 import java.util.ArrayList;
 import java.util.List;
 
-public record PayslipNamesRuleData(Name expectedName, List<PayslipNamesEntry> payslipNamesEntryList) implements RuleData {
+public record PayslipNamesRuleData(
+        Name expectedName,
+        List<PayslipNamesEntry> payslipEntriesInError
+) implements RuleData {
 
-    public PayslipNamesRuleData addItem(PayslipNamesEntry payslipNamesEntry) {
-        List<PayslipNamesEntry> newList = new ArrayList<>(this.payslipNamesEntryList);
-        newList.add(payslipNamesEntry);
+    public PayslipNamesRuleData addItem(PayslipNamesEntry errorEntry) {
+        List<PayslipNamesEntry> newList = new ArrayList<>(this.payslipEntriesInError);
+        newList.add(errorEntry);
         return new PayslipNamesRuleData(this.expectedName, newList);
     }
 
@@ -21,7 +24,7 @@ public record PayslipNamesRuleData(Name expectedName, List<PayslipNamesEntry> pa
     public record PayslipNamesEntry(
             Long fileId,
             String fileName,
-            String ExtractedName
+            String extractedName
     ) {
     }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/RuleData.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/rule/RuleData.java
@@ -16,13 +16,15 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = TaxNamesRuleData.class, name = RuleData.R_TAX_NAMES),
         @JsonSubTypes.Type(value = PayslipContinuityRuleData.class, name = RuleData.R_PAYSLIP_CONTINUITY),
         @JsonSubTypes.Type(value = PayslipNamesRuleData.class, name = RuleData.R_PAYSLIP_NAMES),
+        @JsonSubTypes.Type(value = PayslipClassificationRuleData.class, name = RuleData.R_PAYSLIP_CLASSIFICATION),
 })
-public sealed interface RuleData permits ExpirationRuleData, NamesRuleData, PayslipContinuityRuleData, PayslipNamesRuleData, TaxClassificationRuleData, TaxNamesRuleData, TaxYearsRuleData {
+public sealed interface RuleData permits ExpirationRuleData, NamesRuleData, PayslipClassificationRuleData, PayslipContinuityRuleData, PayslipNamesRuleData, TaxClassificationRuleData, TaxNamesRuleData, TaxYearsRuleData {
     String R_EXPIRATION = "R_EXPIRATION";
     String R_TAX_CLASSIFICATION = "R_TAX_CLASSIFICATION";
     String R_TAX_YEARS = "R_TAX_YEARS";
     String R_TAX_NAMES = "R_TAX_NAMES";
     String R_NAMES = "R_NAMES";
+    String R_PAYSLIP_CLASSIFICATION = "R_PAYSLIP_CLASSIFICATION";
     String R_PAYSLIP_CONTINUITY = "R_PAYSLIP_CONTINUITY";
     String R_PAYSLIP_NAMES = "R_PAYSLIP_NAMES";
 

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
@@ -118,4 +118,27 @@ class DocumentAnalysisRuleTest {
         assertThat(deserializedData.missingMonthList()).containsExactly(ym2);
         assertThat(deserializedRule.getRuleData().getType()).isEqualTo(RuleData.R_PAYSLIP_CONTINUITY);
     }
+
+    @Test
+    void should_serialize_and_deserialize_PayslipClassificationRuleData() throws Exception {
+        PayslipClassificationRuleData.PayslipClassificationEntry entry =
+                new PayslipClassificationRuleData.PayslipClassificationEntry(7L, "file-7.pdf");
+        YearMonth expectedMonth = YearMonth.of(2023, 3);
+        RuleData ruleData = new PayslipClassificationRuleData(List.of(entry), List.of(expectedMonth));
+
+        DocumentAnalysisRule rule = DocumentAnalysisRule.builder()
+                .rule(DocumentRule.R_DOCUMENT_IA_CLASSIFICATION)
+                .ruleData(ruleData)
+                .build();
+
+        String json = objectMapper.writeValueAsString(rule);
+        DocumentAnalysisRule deserializedRule = objectMapper.readValue(json, DocumentAnalysisRule.class);
+
+        assertThat(deserializedRule.getRule()).isEqualTo(DocumentRule.R_DOCUMENT_IA_CLASSIFICATION);
+        assertThat(deserializedRule.getRuleData()).isInstanceOf(PayslipClassificationRuleData.class);
+        PayslipClassificationRuleData deserializedData = (PayslipClassificationRuleData) deserializedRule.getRuleData();
+        assertThat(deserializedData.entriesInError()).containsExactly(entry);
+        assertThat(deserializedData.expectedMonths()).containsExactly(expectedMonth);
+        assertThat(deserializedRule.getRuleData().getType()).isEqualTo(RuleData.R_PAYSLIP_CLASSIFICATION);
+    }
 }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
@@ -97,7 +97,10 @@ class DocumentAnalysisRuleTest {
     void should_serialize_and_deserialize_PayslipContinuityRuleData() throws Exception {
         YearMonth ym1 = YearMonth.of(2023, 1);
         YearMonth ym2 = YearMonth.of(2023, 2);
-        RuleData ruleData = new PayslipContinuityRuleData(List.of(ym1, ym2), List.of(ym1));
+        YearMonth ym3 = YearMonth.of(2023, 3);
+        PayslipContinuityRuleData.PayslipContinuityEntry invalidEntry =
+                new PayslipContinuityRuleData.PayslipContinuityEntry(42L, "file-42.pdf", ym1);
+        RuleData ruleData = new PayslipContinuityRuleData(List.of(ym1, ym2, ym3), List.of(invalidEntry), List.of(ym2));
 
         DocumentAnalysisRule rule = DocumentAnalysisRule.builder()
                 .rule(DocumentRule.R_PAYSLIP_CONTINUITY)
@@ -110,8 +113,9 @@ class DocumentAnalysisRuleTest {
         assertThat(deserializedRule.getRule()).isEqualTo(DocumentRule.R_PAYSLIP_CONTINUITY);
         assertThat(deserializedRule.getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
         PayslipContinuityRuleData deserializedData = (PayslipContinuityRuleData) deserializedRule.getRuleData();
-        assertThat(deserializedData.expectedMonthList()).containsExactly(ym1, ym2);
-        assertThat(deserializedData.extractedMonthList()).containsExactly(ym1);
+        assertThat(deserializedData.expectedMonthList()).containsExactly(ym1, ym2, ym3);
+        assertThat(deserializedData.payslipContinuityEntries()).containsExactly(invalidEntry);
+        assertThat(deserializedData.missingMonthList()).containsExactly(ym2);
         assertThat(deserializedRule.getRuleData().getType()).isEqualTo(RuleData.R_PAYSLIP_CONTINUITY);
     }
 }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/DocumentAnalysisRuleTest.java
@@ -114,7 +114,7 @@ class DocumentAnalysisRuleTest {
         assertThat(deserializedRule.getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
         PayslipContinuityRuleData deserializedData = (PayslipContinuityRuleData) deserializedRule.getRuleData();
         assertThat(deserializedData.expectedMonthList()).containsExactly(ym1, ym2, ym3);
-        assertThat(deserializedData.payslipContinuityEntries()).containsExactly(invalidEntry);
+        assertThat(deserializedData.payslipEntriesInError()).containsExactly(invalidEntry);
         assertThat(deserializedData.missingMonthList()).containsExactly(ym2);
         assertThat(deserializedRule.getRuleData().getType()).isEqualTo(RuleData.R_PAYSLIP_CONTINUITY);
     }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/BulletinSalaireRulesValidationService.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/BulletinSalaireRulesValidationService.java
@@ -3,8 +3,8 @@ package fr.dossierfacile.document.analysis.rule;
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.enums.DocumentCategoryStep;
 import fr.dossierfacile.document.analysis.rule.validator.AbstractDocumentRuleValidator;
-import fr.dossierfacile.document.analysis.rule.validator.document_ia.ClassificationValidatorB;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.HasBeenDocumentIAAnalysedBI;
+import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipClassificationValidatorB;
 import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipContinuityRule;
 import fr.dossierfacile.document.analysis.rule.validator.payslip.PayslipNamesRule;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +18,6 @@ import java.util.List;
 @Slf4j
 public class BulletinSalaireRulesValidationService extends AbstractRulesValidationService {
 
-    private static final String DOCUMENT_IA_DOCUMENT_TYPE = "bulletin_salaire";
-
     @Override
     List<AbstractDocumentRuleValidator> getDocumentRuleValidators(Document document) {
         if (document.getDocumentCategoryStep() == DocumentCategoryStep.SALARY_EMPLOYED_NOT_YET) {
@@ -28,7 +26,7 @@ public class BulletinSalaireRulesValidationService extends AbstractRulesValidati
 
         return List.of(
                 new HasBeenDocumentIAAnalysedBI(),
-                new ClassificationValidatorB(DOCUMENT_IA_DOCUMENT_TYPE),
+                new PayslipClassificationValidatorB(),
                 new PayslipNamesRule(),
                 new PayslipContinuityRule()
         );

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/BasePayslipRuleValidator.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/BasePayslipRuleValidator.java
@@ -1,6 +1,7 @@
 package fr.dossierfacile.document.analysis.rule.validator.payslip;
 
 
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
 
 import java.time.Clock;
@@ -24,6 +25,20 @@ public abstract class BasePayslipRuleValidator extends BaseDocumentIAValidator {
         return (localDate.getDayOfMonth() <= 15) ?
                 List.of(yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3), yearMonth.minusMonths(4)) :
                 List.of(yearMonth, yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3));
+    }
+
+    protected String getFileName(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getStorageFile().getName();
+    }
+
+    protected Long getFileId(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getId();
     }
 
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/BasePayslipRuleValidator.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/BasePayslipRuleValidator.java
@@ -1,0 +1,29 @@
+package fr.dossierfacile.document.analysis.rule.validator.payslip;
+
+
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+public abstract class BasePayslipRuleValidator extends BaseDocumentIAValidator {
+
+    private final Clock clock;
+
+    protected BasePayslipRuleValidator(Clock clock) {
+        this.clock = clock;
+    }
+
+    protected List<YearMonth> getExpectedMonthsLists() {
+        LocalDate localDate = LocalDate.now(clock);
+        YearMonth yearMonth = YearMonth.now(clock);
+        // If before the 15th, we expect M - 2, M - 3, M - 4
+        // Else we expect M - 1, M - 2, M -3
+        return (localDate.getDayOfMonth() <= 15) ?
+                List.of(yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3), yearMonth.minusMonths(4)) :
+                List.of(yearMonth, yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3));
+    }
+
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorB.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorB.java
@@ -1,0 +1,88 @@
+package fr.dossierfacile.document.analysis.rule.validator.payslip;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentAnalysisRule;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.entity.rule.PayslipClassificationRuleData;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+
+import java.time.Clock;
+import java.util.ArrayList;
+
+public class PayslipClassificationValidatorB extends BasePayslipRuleValidator {
+
+	private static final String EXPECTED_DOCUMENT_TYPE = "bulletin_salaire";
+
+	public PayslipClassificationValidatorB() {
+		super(Clock.systemDefaultZone());
+	}
+
+	@Override
+	protected boolean isBlocking() {
+		return true;
+	}
+
+	@Override
+	protected boolean isInconclusive() {
+		return false;
+	}
+
+	@Override
+	protected DocumentRule getRule() {
+		return DocumentRule.R_DOCUMENT_IA_CLASSIFICATION;
+	}
+
+	@Override
+	public RuleValidatorOutput validate(Document document) {
+		var documentIAAnalyses = this.getSuccessfulDocumentIAAnalyses(document);
+		var ruleData = new PayslipClassificationRuleData(new ArrayList<>(), getExpectedMonthsLists());
+
+		if (documentIAAnalyses.isEmpty()) {
+			return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), ruleData), RuleValidatorOutput.RuleLevel.FAILED);
+		}
+
+		for (DocumentIAFileAnalysis analysis : documentIAAnalyses) {
+			String documentType = null;
+			if (analysis.getResult() != null && analysis.getResult().getClassification() != null) {
+				documentType = analysis.getResult().getClassification().getDocumentType();
+			}
+
+			if (!EXPECTED_DOCUMENT_TYPE.equals(documentType)) {
+				ruleData = ruleData.addItem(
+						new PayslipClassificationRuleData.PayslipClassificationEntry(
+								getFileId(analysis),
+								getFileName(analysis)
+						)
+				);
+			}
+		}
+
+		if (ruleData.entriesInError().isEmpty()) {
+			return new RuleValidatorOutput(true, isBlocking(), DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), ruleData), RuleValidatorOutput.RuleLevel.PASSED);
+		}
+
+		return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), ruleData), RuleValidatorOutput.RuleLevel.FAILED);
+	}
+
+	private String getFileName(DocumentIAFileAnalysis analysis) {
+		if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
+			return null;
+		}
+		return analysis.getFile().getStorageFile().getName();
+	}
+
+	private Long getFileId(DocumentIAFileAnalysis analysis) {
+		if (analysis.getFile() == null) {
+			return null;
+		}
+		return analysis.getFile().getId();
+	}
+
+	@Override
+	protected boolean isValid(Document document) {
+		return false;
+	}
+}
+

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorB.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorB.java
@@ -66,20 +66,6 @@ public class PayslipClassificationValidatorB extends BasePayslipRuleValidator {
 		return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), ruleData), RuleValidatorOutput.RuleLevel.FAILED);
 	}
 
-	private String getFileName(DocumentIAFileAnalysis analysis) {
-		if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
-			return null;
-		}
-		return analysis.getFile().getStorageFile().getName();
-	}
-
-	private Long getFileId(DocumentIAFileAnalysis analysis) {
-		if (analysis.getFile() == null) {
-			return null;
-		}
-		return analysis.getFile().getId();
-	}
-
 	@Override
 	protected boolean isValid(Document document) {
 		return false;

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
@@ -2,6 +2,7 @@ package fr.dossierfacile.document.analysis.rule.validator.payslip;
 
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentAnalysisRule;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.DocumentRule;
 import fr.dossierfacile.common.entity.rule.PayslipContinuityRuleData;
 import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
@@ -12,7 +13,10 @@ import fr.dossierfacile.document.analysis.rule.validator.payslip.document_ia_mod
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class PayslipContinuityRule extends BaseDocumentIAValidator {
 
@@ -53,23 +57,43 @@ public class PayslipContinuityRule extends BaseDocumentIAValidator {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFrom(getRule()), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
         }
 
-        var extractedDates = new DocumentIAMultiMapper().map(documentIAAnalyses, PayslipDate.class);
+        var expectedMonths = getExpectedMonthsLists();
+        var continuityRuleData = new PayslipContinuityRuleData(expectedMonths, new ArrayList<>(), List.of());
+        DocumentIAMultiMapper mapper = new DocumentIAMultiMapper();
+        List<YearMonth> validExtractedMonths = new ArrayList<>();
+        for (DocumentIAFileAnalysis analysis : documentIAAnalyses) {
+            PayslipDate payslipDate = mapper.map(List.of(analysis), PayslipDate.class)
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
 
-        if (extractedDates.stream().anyMatch(it -> it.startDate == null)) {
-            return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFrom(getRule()), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+            YearMonth extractedMonth = null;
+            if (payslipDate != null && payslipDate.startDate != null) {
+                extractedMonth = YearMonth.from(payslipDate.startDate);
+            }
+
+            if (extractedMonth == null || !expectedMonths.contains(extractedMonth)) {
+                continuityRuleData = continuityRuleData.addItem(
+                        new PayslipContinuityRuleData.PayslipContinuityEntry(
+                                getFileId(analysis),
+                                getFileName(analysis),
+                                extractedMonth
+                        )
+                );
+                continue;
+            }
+
+            validExtractedMonths.add(extractedMonth);
         }
 
-        var expectedMonths = getExpectedMonthsLists();
-        var extractedMonths = getExtractedMonths(extractedDates);
+        List<YearMonth> distinctValidMonths = validExtractedMonths.stream().distinct().toList();
+        List<YearMonth> missingMonthList = computeMissingMonths(expectedMonths, distinctValidMonths);
+        continuityRuleData = continuityRuleData.withMissingMonthList(missingMonthList);
 
-        List<YearMonth> validMonths = extractedMonths.stream()
-                .filter(expectedMonths::contains)
-                .sorted()
-                .toList();
-
-        var continuityRuleData = new PayslipContinuityRuleData(expectedMonths, extractedMonths);
-
-        var isValid = hasThreeConsecutiveMonths(validMonths);
+        // Règle métier: il faut au moins 3 mois attendus consécutifs.
+        var isValid = hasThreeConsecutiveMonths(
+                distinctValidMonths.stream().sorted().toList()
+        );
 
         if (isValid) {
             return new RuleValidatorOutput(
@@ -94,10 +118,16 @@ public class PayslipContinuityRule extends BaseDocumentIAValidator {
         }
     }
 
+    @Override
+    protected boolean isValid(Document document) {
+        return false;
+    }
+
     private boolean hasThreeConsecutiveMonths(List<YearMonth> months) {
         if (months.size() < 3) {
             return false;
         }
+
         int consecutiveCount = 1;
         for (int i = 0; i < months.size() - 1; i++) {
             if (months.get(i).plusMonths(1).equals(months.get(i + 1))) {
@@ -112,9 +142,11 @@ public class PayslipContinuityRule extends BaseDocumentIAValidator {
         return false;
     }
 
-    @Override
-    protected boolean isValid(Document document) {
-        return false;
+    private List<YearMonth> computeMissingMonths(List<YearMonth> expectedMonths, List<YearMonth> validExtractedMonths) {
+        Set<YearMonth> extractedSet = new HashSet<>(validExtractedMonths);
+        return expectedMonths.stream()
+                .filter(expectedMonth -> !extractedSet.contains(expectedMonth))
+                .toList();
     }
 
     private List<YearMonth> getExpectedMonthsLists() {
@@ -127,14 +159,17 @@ public class PayslipContinuityRule extends BaseDocumentIAValidator {
                 List.of(yearMonth, yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3));
     }
 
-    // We need to extract YearMonth from DocumentDate based on startDate and endDate
-    private List<YearMonth> getExtractedMonths(List<PayslipDate> extractedDates) {
-        return extractedDates.stream()
-                .map(date -> {
-                    LocalDate startDate = date.startDate;
-                    return YearMonth.from(startDate);
-                })
-                .distinct()
-                .toList();
+    private String getFileName(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getStorageFile().getName();
+    }
+
+    private Long getFileId(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getId();
     }
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
@@ -144,18 +144,4 @@ public class PayslipContinuityRule extends BasePayslipRuleValidator {
                 .filter(expectedMonth -> !extractedSet.contains(expectedMonth))
                 .toList();
     }
-
-    private String getFileName(DocumentIAFileAnalysis analysis) {
-        if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
-            return null;
-        }
-        return analysis.getFile().getStorageFile().getName();
-    }
-
-    private Long getFileId(DocumentIAFileAnalysis analysis) {
-        if (analysis.getFile() == null) {
-            return null;
-        }
-        return analysis.getFile().getId();
-    }
 }

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRule.java
@@ -6,28 +6,24 @@ import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.DocumentRule;
 import fr.dossierfacile.common.entity.rule.PayslipContinuityRuleData;
 import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
-import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
 import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAMultiMapper;
 import fr.dossierfacile.document.analysis.rule.validator.payslip.document_ia_model.PayslipDate;
 
 import java.time.Clock;
-import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class PayslipContinuityRule extends BaseDocumentIAValidator {
-
-    private final Clock clock;
+public class PayslipContinuityRule extends BasePayslipRuleValidator {
 
     public PayslipContinuityRule() {
-        this(Clock.systemDefaultZone());
+        super(Clock.systemDefaultZone());
     }
 
     public PayslipContinuityRule(Clock clock) {
-        this.clock = clock;
+        super(clock);
     }
 
     @Override
@@ -147,16 +143,6 @@ public class PayslipContinuityRule extends BaseDocumentIAValidator {
         return expectedMonths.stream()
                 .filter(expectedMonth -> !extractedSet.contains(expectedMonth))
                 .toList();
-    }
-
-    private List<YearMonth> getExpectedMonthsLists() {
-        LocalDate localDate = LocalDate.now(clock);
-        YearMonth yearMonth = YearMonth.now(clock);
-        // If before the 15th, we expect M - 2, M - 3, M - 4
-        // Else we expect M - 1, M - 2, M -3
-        return (localDate.getDayOfMonth() <= 15) ?
-                List.of(yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3), yearMonth.minusMonths(4)) :
-                List.of(yearMonth, yearMonth.minusMonths(1), yearMonth.minusMonths(2), yearMonth.minusMonths(3));
     }
 
     private String getFileName(DocumentIAFileAnalysis analysis) {

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
@@ -2,6 +2,7 @@ package fr.dossierfacile.document.analysis.rule.validator.payslip;
 
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentAnalysisRule;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.DocumentRule;
 import fr.dossierfacile.common.entity.rule.PayslipNamesRuleData;
 import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
@@ -69,19 +70,17 @@ public class PayslipNamesRule extends BaseDocumentIAValidator {
     @Override
     public RuleValidatorOutput validate(Document document) {
         var documentIAAnalyses = this.getSuccessfulDocumentIAAnalyses(document);
-
         var nameToMatch = getNamesFromDocument(document);
 
-        PayslipNamesRuleData namesRuleData = null;
-
+        PayslipNamesRuleData.Name expectedName = null;
         if (nameToMatch != null) {
-            var expectedName = new PayslipNamesRuleData.Name(
+            expectedName = new PayslipNamesRuleData.Name(
                     nameToMatch.getFirstNamesAsString(),
                     nameToMatch.getLastName(),
                     nameToMatch.getPreferredName()
             );
-            namesRuleData = new PayslipNamesRuleData(expectedName, List.of());
         }
+        PayslipNamesRuleData namesRuleData = new PayslipNamesRuleData(expectedName, new ArrayList<>());
 
         if (documentIAAnalyses.isEmpty() || hasAnyNonSuccessfulDocumentIAAnalyses(document)) {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
@@ -91,21 +90,20 @@ public class PayslipNamesRule extends BaseDocumentIAValidator {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
         }
 
-        var extractedPayslips = new DocumentIAMultiMapper().map(documentIAAnalyses, PayslipNames.class);
-
-        if (extractedPayslips.isEmpty()) {
-            return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
-        }
-
-        var listOfExtractedIdentities = new ArrayList<String>();
-        var isNameMatch = true;
-
-        for (PayslipNames payslip : extractedPayslips) {
-            String identityString = payslip.getIdentityString();
-            listOfExtractedIdentities.add(identityString);
+        DocumentIAMultiMapper mapper = new DocumentIAMultiMapper();
+        for (var analysis : documentIAAnalyses) {
+            String identityString = mapper.map(List.of(analysis), PayslipNames.class)
+                    .stream()
+                    .findFirst()
+                    .map(PayslipNames::getIdentityString)
+                    .orElse(null);
 
             if (identityString == null) {
-                isNameMatch = false;
+                namesRuleData = namesRuleData.addItem(new PayslipNamesRuleData.PayslipNamesEntry(
+                        getFileId(analysis),
+                        getFileName(analysis),
+                        null
+                ));
                 continue;
             }
 
@@ -114,17 +112,33 @@ public class PayslipNamesRule extends BaseDocumentIAValidator {
             boolean firstNameMatches = IdentityMatchUtil.hasFirstNameMatch(identities, nameToMatch);
 
             if (!lastNameMatches || !firstNameMatches) {
-                isNameMatch = false;
+                namesRuleData = namesRuleData.addItem(new PayslipNamesRuleData.PayslipNamesEntry(
+                        getFileId(analysis),
+                        getFileName(analysis),
+                        identityString
+                ));
             }
         }
 
-        namesRuleData = new PayslipNamesRuleData(namesRuleData, listOfExtractedIdentities);
-
-        if (isNameMatch) {
+        if (namesRuleData.payslipNamesEntryList().isEmpty()) {
             return new RuleValidatorOutput(true, isBlocking(), DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.PASSED);
         } else {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.FAILED);
         }
+    }
+
+    private String getFileName(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null || analysis.getFile().getStorageFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getStorageFile().getName();
+    }
+
+    private Long getFileId(DocumentIAFileAnalysis analysis) {
+        if (analysis.getFile() == null) {
+            return null;
+        }
+        return analysis.getFile().getId();
     }
 
     @Override

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRule.java
@@ -120,7 +120,7 @@ public class PayslipNamesRule extends BaseDocumentIAValidator {
             }
         }
 
-        if (namesRuleData.payslipNamesEntryList().isEmpty()) {
+        if (namesRuleData.payslipEntriesInError().isEmpty()) {
             return new RuleValidatorOutput(true, isBlocking(), DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.PASSED);
         } else {
             return new RuleValidatorOutput(false, isBlocking(), DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), namesRuleData), RuleValidatorOutput.RuleLevel.FAILED);

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorBTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipClassificationValidatorBTest.java
@@ -1,0 +1,126 @@
+package fr.dossierfacile.document.analysis.rule.validator.payslip;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.StorageFile;
+import fr.dossierfacile.common.entity.rule.PayslipClassificationRuleData;
+import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.ClassificationModel;
+import fr.dossierfacile.common.model.document_ia.ResultModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayslipClassificationValidatorBTest {
+
+    private final PayslipClassificationValidatorB rule = new PayslipClassificationValidatorB();
+
+    @Test
+    @DisplayName("PASSED quand tous les fichiers sont classifiés bulletin_salaire")
+    void should_pass_when_all_files_are_payslip() {
+        Document document = documentWithAnalyses(
+                analysisWithClassification("bulletin_salaire"),
+                analysisWithClassification("bulletin_salaire")
+        );
+
+        RuleValidatorOutput output = rule.validate(document);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.rule().getRule()).isEqualTo(DocumentRule.R_DOCUMENT_IA_CLASSIFICATION);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipClassificationRuleData.class);
+        PayslipClassificationRuleData data = (PayslipClassificationRuleData) output.rule().getRuleData();
+        assertThat(data.entriesInError()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("FAILED quand un fichier n'est pas classifié bulletin_salaire")
+    void should_fail_and_return_entries_in_error_when_one_file_is_not_payslip() {
+        Document document = documentWithAnalyses(
+                analysisWithClassification("bulletin_salaire"),
+                analysisWithClassification("carte_identite")
+        );
+
+        RuleValidatorOutput output = rule.validate(document);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipClassificationRuleData.class);
+        PayslipClassificationRuleData data = (PayslipClassificationRuleData) output.rule().getRuleData();
+        assertThat(data.entriesInError()).hasSize(1);
+        assertThat(data.entriesInError().get(0).fileId()).isEqualTo(2L);
+        assertThat(data.entriesInError().get(0).fileName()).isEqualTo("file-2.pdf");
+    }
+
+    @Test
+    @DisplayName("FAILED quand la classification est absente")
+    void should_fail_when_classification_is_missing() {
+        Document document = documentWithAnalyses(
+                analysisWithClassification("bulletin_salaire"),
+                analysisWithNoClassification()
+        );
+
+        RuleValidatorOutput output = rule.validate(document);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        PayslipClassificationRuleData data = (PayslipClassificationRuleData) output.rule().getRuleData();
+        assertThat(data.entriesInError()).hasSize(1);
+        assertThat(data.entriesInError().get(0).fileId()).isEqualTo(2L);
+        assertThat(data.entriesInError().get(0).fileName()).isEqualTo("file-2.pdf");
+    }
+
+    @Test
+    @DisplayName("FAILED quand aucune analyse n'est disponible")
+    void should_fail_when_no_analysis() {
+        Document document = Document.builder().files(List.of()).build();
+
+        RuleValidatorOutput output = rule.validate(document);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipClassificationRuleData.class);
+        PayslipClassificationRuleData data = (PayslipClassificationRuleData) output.rule().getRuleData();
+        assertThat(data.entriesInError()).isEmpty();
+    }
+
+    private Document documentWithAnalyses(DocumentIAFileAnalysis... analyses) {
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < analyses.length; i++) {
+            DocumentIAFileAnalysis analysis = analyses[i];
+            File file = File.builder()
+                    .id((long) (i + 1))
+                    .storageFile(StorageFile.builder().name("file-" + (i + 1) + ".pdf").build())
+                    .documentIAFileAnalysis(analysis)
+                    .build();
+            if (analysis != null) {
+                analysis.setFile(file);
+            }
+            files.add(file);
+        }
+        return Document.builder().files(files).build();
+    }
+
+    private DocumentIAFileAnalysis analysisWithClassification(String documentType) {
+        ResultModel result = ResultModel.builder()
+                .classification(ClassificationModel.builder().documentType(documentType).build())
+                .build();
+        return DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(result)
+                .build();
+    }
+
+    private DocumentIAFileAnalysis analysisWithNoClassification() {
+        ResultModel result = ResultModel.builder()
+                .classification(null)
+                .build();
+        return DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(result)
+                .build();
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
@@ -319,10 +319,10 @@ class PayslipContinuityRuleTest {
         assertThat(result.rule().getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
 
         PayslipContinuityRuleData data = (PayslipContinuityRuleData) result.rule().getRuleData();
-        assertThat(data.payslipContinuityEntries()).hasSize(1);
-        assertThat(data.payslipContinuityEntries().get(0).fileId()).isEqualTo(3L);
-        assertThat(data.payslipContinuityEntries().get(0).fileName()).isEqualTo("file-3.pdf");
-        assertThat(data.payslipContinuityEntries().get(0).extractedMonth()).isEqualTo(YearMonth.of(2022, 12));
+        assertThat(data.payslipEntriesInError()).hasSize(1);
+        assertThat(data.payslipEntriesInError().get(0).fileId()).isEqualTo(3L);
+        assertThat(data.payslipEntriesInError().get(0).fileName()).isEqualTo("file-3.pdf");
+        assertThat(data.payslipEntriesInError().get(0).extractedMonth()).isEqualTo(YearMonth.of(2022, 12));
     }
 
     @Test
@@ -343,7 +343,7 @@ class PayslipContinuityRuleTest {
         assertThat(result.rule().getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
 
         PayslipContinuityRuleData data = (PayslipContinuityRuleData) result.rule().getRuleData();
-        assertThat(data.payslipContinuityEntries()).isEmpty();
+        assertThat(data.payslipEntriesInError()).isEmpty();
         assertThat(data.missingMonthList()).contains(YearMonth.of(2023, 3));
     }
 

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipContinuityRuleTest.java
@@ -3,6 +3,8 @@ package fr.dossierfacile.document.analysis.rule.validator.payslip;
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.StorageFile;
+import fr.dossierfacile.common.entity.rule.PayslipContinuityRuleData;
 import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
 import fr.dossierfacile.common.model.document_ia.BarcodeModel;
 import fr.dossierfacile.common.model.document_ia.ExtractionModel;
@@ -17,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -42,8 +45,12 @@ class PayslipContinuityRuleTest {
 
     private Document createDocumentWithAnalyses(DocumentIAFileAnalysis... analyses) {
         List<File> files = new ArrayList<>();
-        for (DocumentIAFileAnalysis analysis : analyses) {
-            File file = File.builder().build();
+        for (int i = 0; i < analyses.length; i++) {
+            DocumentIAFileAnalysis analysis = analyses[i];
+            File file = File.builder()
+                    .id((long) (i + 1))
+                    .storageFile(StorageFile.builder().name("file-" + (i + 1) + ".pdf").build())
+                    .build();
             file.setDocumentIAFileAnalysis(analysis);
             if (analysis != null) {
                 analysis.setFile(file);
@@ -182,6 +189,13 @@ class PayslipContinuityRuleTest {
                         LocalDate.of(2023, 4, 20),
                         List.of(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 1, 1), LocalDate.of(2022, 12, 1)),
                         false
+                ),
+                // Cas 10 : 10 Avril (<=15).
+                // Scénario : Mars, Fev, Jan, Dec, Novembre -> OK (5 présents, donc 3 consécutifs ok)
+                Arguments.of(
+                        LocalDate.of(2023, 4, 10),
+                        List.of(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 2, 1), LocalDate.of(2023, 1, 1), LocalDate.of(2022, 12, 1), LocalDate.of(2022, 11, 1)),
+                        true
                 )
         );
     }
@@ -285,6 +299,52 @@ class PayslipContinuityRuleTest {
         // Mars + Fev + Jan = 3 consécutifs dans la fenêtre → PASSED
         assertThat(output.isValid()).isTrue();
         assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    @DisplayName("FAILED et RuleData renseignée quand au moins un fichier est hors expectedMonths")
+    void should_fail_with_rule_data_when_one_file_is_outside_expected_months() {
+        PayslipContinuityRule validator = createValidator(LocalDate.of(2023, 4, 20));
+
+        DocumentIAFileAnalysis[] analyses = new DocumentIAFileAnalysis[]{
+                analysisWithDate(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 30)),
+                analysisWithDate(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28)),
+                analysisWithDate(LocalDate.of(2022, 12, 1), LocalDate.of(2022, 12, 31))
+        };
+
+        Document document = createDocumentWithAnalyses(analyses);
+        RuleValidatorOutput result = validator.validate(document);
+
+        assertThat(result.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(result.rule().getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
+
+        PayslipContinuityRuleData data = (PayslipContinuityRuleData) result.rule().getRuleData();
+        assertThat(data.payslipContinuityEntries()).hasSize(1);
+        assertThat(data.payslipContinuityEntries().get(0).fileId()).isEqualTo(3L);
+        assertThat(data.payslipContinuityEntries().get(0).fileName()).isEqualTo("file-3.pdf");
+        assertThat(data.payslipContinuityEntries().get(0).extractedMonth()).isEqualTo(YearMonth.of(2022, 12));
+    }
+
+    @Test
+    @DisplayName("FAILED et missingMonthList contient Mars quand Avril/Fev/Jan sont fournis")
+    void should_include_march_in_missing_month_list_for_case_5() {
+        PayslipContinuityRule validator = createValidator(LocalDate.of(2023, 5, 10));
+
+        DocumentIAFileAnalysis[] analyses = new DocumentIAFileAnalysis[]{
+                analysisWithDate(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 30)),
+                analysisWithDate(LocalDate.of(2023, 2, 1), LocalDate.of(2023, 2, 28)),
+                analysisWithDate(LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31))
+        };
+
+        Document document = createDocumentWithAnalyses(analyses);
+        RuleValidatorOutput result = validator.validate(document);
+
+        assertThat(result.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(result.rule().getRuleData()).isInstanceOf(PayslipContinuityRuleData.class);
+
+        PayslipContinuityRuleData data = (PayslipContinuityRuleData) result.rule().getRuleData();
+        assertThat(data.payslipContinuityEntries()).isEmpty();
+        assertThat(data.missingMonthList()).contains(YearMonth.of(2023, 3));
     }
 
     @Test

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
@@ -5,7 +5,9 @@ import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
 import fr.dossierfacile.common.entity.DocumentRule;
 import fr.dossierfacile.common.entity.File;
 import fr.dossierfacile.common.entity.Guarantor;
+import fr.dossierfacile.common.entity.StorageFile;
 import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.entity.rule.PayslipNamesRuleData;
 import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
 import fr.dossierfacile.common.model.document_ia.BarcodeModel;
 import fr.dossierfacile.common.model.document_ia.ExtractionModel;
@@ -94,11 +96,19 @@ class PayslipNamesRuleTest {
     }
 
     private Document buildDocument(Tenant tenant, Guarantor guarantor, DocumentIAFileAnalysis... analyses) {
-        List<File> files = Stream.of(analyses).map(analysis -> {
-            File file = File.builder().documentIAFileAnalysis(analysis).build();
-            if (analysis != null) analysis.setFile(file);
-            return file;
-        }).toList();
+        List<File> files = new ArrayList<>();
+        for (int i = 0; i < analyses.length; i++) {
+            DocumentIAFileAnalysis analysis = analyses[i];
+            File file = File.builder()
+                    .id((long) (i + 1))
+                    .documentIAFileAnalysis(analysis)
+                    .storageFile(StorageFile.builder().name("file-" + (i + 1) + ".pdf").build())
+                    .build();
+            if (analysis != null) {
+                analysis.setFile(file);
+            }
+            files.add(file);
+        }
 
         Document doc = Document.builder().files(files).tenant(tenant).guarantor(guarantor).build();
         files.forEach(f -> f.setDocument(doc));
@@ -143,12 +153,34 @@ class PayslipNamesRuleTest {
     }
 
     @Test
-    @DisplayName("INCONCLUSIVE si identite_salarie est absent de l'extraction et pas de 2DDoc")
-    void inconclusive_when_identity_null_in_extraction_and_no_2ddoc() {
+    @DisplayName("FAILED si identite_salarie est absent de l'extraction et pas de 2DDoc")
+    void failed_when_identity_null_in_extraction_and_no_2ddoc() {
         DocumentIAFileAnalysis analysis = analysisWithExtraction(null);
         Document doc = documentWithTenant("Jean", "Dupont", analysis);
 
-        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        RuleValidatorOutput output = rule.validate(doc);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
+        PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
+        assertThat(data.payslipNamesEntryList()).hasSize(1);
+        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(1L);
+        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-1.pdf");
+        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isNull();
+    }
+
+    @Test
+    @DisplayName("PASSED et RuleData vide quand tous les bulletins matchent")
+    void passed_with_empty_rule_data_when_all_names_match() {
+        DocumentIAFileAnalysis analysis = analysisWithExtraction("MR DUPONT JEAN");
+        Document doc = documentWithTenant("Jean", "Dupont", analysis);
+
+        RuleValidatorOutput out = rule.validate(doc);
+
+        assertThat(out.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(out.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
+        PayslipNamesRuleData data = (PayslipNamesRuleData) out.rule().getRuleData();
+        assertThat(data.payslipNamesEntryList()).isEmpty();
     }
 
     // ==========================
@@ -281,7 +313,19 @@ class PayslipNamesRuleTest {
         DocumentIAFileAnalysis analysis = analysisWithExtraction("MR MARTIN JEAN");
         Document doc = documentWithTenant("Jean", "Dupont", analysis);
 
-        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        RuleValidatorOutput output = rule.validate(doc);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
+        PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
+        assertThat(data.payslipNamesEntryList()).hasSize(1);
+        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(1L);
+        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-1.pdf");
+        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isEqualTo("MR MARTIN JEAN");
+
+        PayslipNamesRuleData.Name expected = data.expectedName();
+        assertThat(expected.firstNames()).isEqualTo("Jean");
+        assertThat(expected.lastName()).isEqualTo("Dupont");
     }
 
     @Test
@@ -317,6 +361,15 @@ class PayslipNamesRuleTest {
 
         Document doc = documentWithTenant("Jean", "Dupont", match, mismatch);
 
-        assertThat(rule.validate(doc).ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        RuleValidatorOutput output = rule.validate(doc);
+
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
+        PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
+        assertThat(data.payslipNamesEntryList()).hasSize(1);
+        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(2L);
+        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-2.pdf");
+        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isEqualTo("MR MARTIN PIERRE");
+
     }
 }

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/payslip/PayslipNamesRuleTest.java
@@ -163,10 +163,10 @@ class PayslipNamesRuleTest {
         assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
         assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
         PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
-        assertThat(data.payslipNamesEntryList()).hasSize(1);
-        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(1L);
-        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-1.pdf");
-        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isNull();
+        assertThat(data.payslipEntriesInError()).hasSize(1);
+        assertThat(data.payslipEntriesInError().get(0).fileId()).isEqualTo(1L);
+        assertThat(data.payslipEntriesInError().get(0).fileName()).isEqualTo("file-1.pdf");
+        assertThat(data.payslipEntriesInError().get(0).extractedName()).isNull();
     }
 
     @Test
@@ -180,7 +180,7 @@ class PayslipNamesRuleTest {
         assertThat(out.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
         assertThat(out.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
         PayslipNamesRuleData data = (PayslipNamesRuleData) out.rule().getRuleData();
-        assertThat(data.payslipNamesEntryList()).isEmpty();
+        assertThat(data.payslipEntriesInError()).isEmpty();
     }
 
     // ==========================
@@ -318,10 +318,10 @@ class PayslipNamesRuleTest {
         assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
         assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
         PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
-        assertThat(data.payslipNamesEntryList()).hasSize(1);
-        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(1L);
-        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-1.pdf");
-        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isEqualTo("MR MARTIN JEAN");
+        assertThat(data.payslipEntriesInError()).hasSize(1);
+        assertThat(data.payslipEntriesInError().get(0).fileId()).isEqualTo(1L);
+        assertThat(data.payslipEntriesInError().get(0).fileName()).isEqualTo("file-1.pdf");
+        assertThat(data.payslipEntriesInError().get(0).extractedName()).isEqualTo("MR MARTIN JEAN");
 
         PayslipNamesRuleData.Name expected = data.expectedName();
         assertThat(expected.firstNames()).isEqualTo("Jean");
@@ -366,10 +366,10 @@ class PayslipNamesRuleTest {
         assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
         assertThat(output.rule().getRuleData()).isInstanceOf(PayslipNamesRuleData.class);
         PayslipNamesRuleData data = (PayslipNamesRuleData) output.rule().getRuleData();
-        assertThat(data.payslipNamesEntryList()).hasSize(1);
-        assertThat(data.payslipNamesEntryList().get(0).fileId()).isEqualTo(2L);
-        assertThat(data.payslipNamesEntryList().get(0).fileName()).isEqualTo("file-2.pdf");
-        assertThat(data.payslipNamesEntryList().get(0).ExtractedName()).isEqualTo("MR MARTIN PIERRE");
+        assertThat(data.payslipEntriesInError()).hasSize(1);
+        assertThat(data.payslipEntriesInError().get(0).fileId()).isEqualTo(2L);
+        assertThat(data.payslipEntriesInError().get(0).fileName()).isEqualTo("file-2.pdf");
+        assertThat(data.payslipEntriesInError().get(0).extractedName()).isEqualTo("MR MARTIN PIERRE");
 
     }
 }


### PR DESCRIPTION
Exemple de retour JSON quand la règle continuity est en erreur : 

*Quand tous les fichiers envoyé sont bon mais qu'il manque 1 des mois de salaire : *
```json
{
  "rule": "PayslipContinuityRuleData",
  "data": {
    "expectedMonthList": [
      "2023-04",
      "2023-03",
      "2023-02",
      "2023-01"
    ],
    "payslipEntriesInError": [],
    "missingMonthList": [
      "2023-03"
    ]
  }
}
```

*Quand un des fichier envoyé n'est pas attendu :*
```json
{
  "rule": "PayslipContinuityRuleData",
  "data" : {
     "expectedMonthList": [
       "2023-04",
       "2023-03",
       "2023-02",
       "2023-01"
     ],
     "payslipEntriesInError": [
         {
            "fileId": 3,
            "fileName": "file-3.pdf",
            "extractedMonth": "2022-12"
        }
     ],
    "missingMonthList": [
       "2023-04",
       "2023-03"
    ]
  }
}
```

Il faut supprimer en DB les lignes : 
```sql
select *
from document as d
         join document_analysis_report as da on d.id = da.document_id
where d.document_category_step = 'SALARY_EMPLOYED_MORE_3_MONTHS'
  and (
    da.failed_rules::text like '%"type": "R_PAYSLIP_NAMES"%'
        or da.failed_rules::text like '%"type": "R_PAYSLIP_CONTINUITY"%'
        or da.inconclusive_rules::text like '%"type": "R_PAYSLIP_NAMES"%'
        or da.inconclusive_rules::text like '%"type": "R_PAYSLIP_CONTINUITY"%'
        or da.passed_rules::text like '%"type": "R_PAYSLIP_NAMES"%'
        or da.passed_rules::text like '%"type": "R_PAYSLIP_CONTINUITY"%'
    );
```

Je n'ai pas fait de migration car ces lignes n'existent pas en prod et ça ne sert a rien d'ajouter une migration pour ça du coup