### PR TITLE
fix: no overflow on pdf for long custom message

### DIFF
--- a/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/EmptyBOPdfDocumentTemplate.java
+++ b/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/EmptyBOPdfDocumentTemplate.java
@@ -106,10 +106,25 @@ public class EmptyBOPdfDocumentTemplate implements PdfTemplate<Document> {
                 String today = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
                 String header = messageSource.getMessage("tenant.document.tax.justification.certify", new String[]{name}, locale);
                 Utility.addText(contentStream, width, startX, startY, header, font, fontSize, alternativeFont);
-                Utility.addText(contentStream, width, startX, startY - 36, textElements.explanation, font, fontSize, alternativeFont);
-                Utility.addText(contentStream, width, startX, startY - 120, String.format("Fait le %s", today), font, fontSize, alternativeFont);
-                Utility.addText(contentStream, width, startX, startY - 156, "Signature", font, fontSize, alternativeFont);
-                Utility.addText(contentStream, width, startX, startY - 180, name, font, fontSize, alternativeFont);
+
+                float headerToExplanation = leading + 12;
+                float explanationToDate = leading + 12;
+                float dateToSignature = leading + 12;
+                float signatureToName = leading;
+
+                float explanationY = startY - headerToExplanation;
+                Utility.addText(contentStream, width, startX, explanationY, textElements.explanation, font, fontSize, alternativeFont);
+
+                int explanationLines = Utility.countLines(textElements.explanation, width, font, fontSize, alternativeFont);
+                float explanationBottomY = explanationY - explanationLines * leading;
+
+                float dateY = explanationBottomY - explanationToDate;
+                float signatureY = dateY - dateToSignature;
+                float nameY = signatureY - signatureToName;
+
+                Utility.addText(contentStream, width, startX, dateY, String.format("Fait le %s", today), font, fontSize, alternativeFont);
+                Utility.addText(contentStream, width, startX, signatureY, "Signature", font, fontSize, alternativeFont);
+                Utility.addText(contentStream, width, startX, nameY, name, font, fontSize, alternativeFont);
             } else {
                 Utility.addText(contentStream, width, startX, startY, textElements.header, font, fontSize, alternativeFont);
                 Utility.addText(contentStream, width, startX, startY - 36, textElements.explanation, font, fontSize, alternativeFont);

--- a/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/util/Utility.java
+++ b/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/util/Utility.java
@@ -81,6 +81,20 @@ public class Utility {
         }).mapToDouble(Number::doubleValue).sum();
     }
 
+    public static int countLines(String text, float width, PDType0Font font,
+                                 float fontSize, PDType0Font alternativeFont) {
+        text = StringUtils.trim(text);
+        if (text.isEmpty()) {
+            return 0;
+        }
+        String[] paragraphs = text.split("[\\r\\n]+");
+        int total = 0;
+        for (String paragraph : paragraphs) {
+            total += sentanceToLines(paragraph, width, font, fontSize, alternativeFont).size();
+        }
+        return total;
+    }
+
     public static List<String> sentanceToLines(String text, float width, PDType0Font font, float fontSize, PDType0Font alternativeFont) {
         List<String> lines = new ArrayList<>();
         int lastSpace = -1;


### PR DESCRIPTION
https://www.notion.so/dossierfacile/Superposition-du-texte-et-de-la-date-dans-l-attestation-sur-l-honneur-avis-d-imposition-autre-33c6cd6935b980ae94e0f3f8434d6f96

<img width="2761" height="1429" alt="image" src="https://github.com/user-attachments/assets/77d1a964-eb35-440a-9e9a-6a6a1d3a35cf" />


