### PR TITLE
feat(bo): check operator access permissions when performing actions on tenant / apartmentSharing and file

### DIFF
--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOApartmentSharingController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOApartmentSharingController.java
@@ -14,12 +14,14 @@ import fr.dossierfacile.common.enums.LinkType;
 import fr.dossierfacile.common.model.document_ia.ResultModel;
 import fr.dossierfacile.common.repository.LinkLogRepository;
 import fr.dossierfacile.common.service.ApartmentSharingLinkService;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.gouv.bo.dto.ApartmentSharingLinkEnrichedDTO;
 import fr.gouv.bo.dto.DisplayableFile;
 import fr.gouv.bo.dto.LinkLogDTO;
 import fr.gouv.bo.dto.MessageDTO;
 import fr.gouv.bo.dto.MetadataItem;
 import fr.gouv.bo.dto.PartnerDTO;
+import fr.gouv.bo.security.BOAccessDenied;
 import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.DocumentService;
@@ -81,6 +83,7 @@ public class BOApartmentSharingController {
     private final LinkLogRepository linkLogRepository;
     private final UserService userService;
     private final BOApplicationAccessService applicationAccessService;
+    private final ApartmentSharingCommonService applicationSharingService;
 
     @Value("${tenant.base.url}")
     private String tenantBaseUrl;
@@ -88,15 +91,17 @@ public class BOApartmentSharingController {
     @GetMapping("/{id}")
     public String view(Model model, @PathVariable("id") Long id,
                        @AuthenticationPrincipal UserPrincipal principal) {
-        applicationAccessService.checkAndLogApartmentSharingAccess(principal, id);
+        ApartmentSharing apartmentSharing = applicationSharingService.findById(id).orElseThrow(BOAccessDenied::generic);
+
+        applicationAccessService.checkAndLogApartmentSharingAccess(principal, apartmentSharing.getId());
 
         MessageDTO messageDTO = new MessageDTO();
         PartnerDTO partnerDTO = new PartnerDTO();
 
-        List<Tenant> tenants = tenantService.findAllTenantsByApartmentSharingAndReorderDocumentsByCategory(id);
+        
 
         // Enrich apartment sharing links with visit data and creator info
-        List<ApartmentSharingLink> filteredLinks = apartmentSharingLinkService.getFilteredLinks(tenants.getFirst().getApartmentSharing());
+        List<ApartmentSharingLink> filteredLinks = apartmentSharingLinkService.getFilteredLinks(apartmentSharing);
 
         List<ApartmentSharingLinkEnrichedDTO> enrichedLinks = enrichApartmentSharingLinks(filteredLinks);
 
@@ -107,6 +112,8 @@ public class BOApartmentSharingController {
         List<ApartmentSharingLinkEnrichedDTO> inactiveLinks = enrichedLinks.stream()
                 .filter(link -> !link.isActive())
                 .toList();
+
+        List<Tenant> tenants = tenantService.findAllTenantsByApartmentSharingAndReorderDocumentsByCategory(id);
 
         model.addAttribute(TENANTS, tenants);
         model.addAttribute(LOG_SER, logService);
@@ -131,15 +138,31 @@ public class BOApartmentSharingController {
     }
 
     @DeleteMapping("/{id}/apartmentSharingLinks/{link_id}")
-    public String deleteToken(@PathVariable Long id, @PathVariable("link_id") Long linkId) {
+    public String deleteToken(
+            @PathVariable Long id,
+            @PathVariable("link_id") Long linkId,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ApartmentSharing apartmentSharing = applicationSharingService.findById(id).orElseThrow(BOAccessDenied::generic);
+
+        applicationAccessService.checkApartmentSharingAccess(principal, apartmentSharing.getId());
+        
         apartmentSharingLinkService.delete(linkId);
         return REDIRECT_BO_COLOCATION + id;
     }
 
     @PutMapping("/{id}/apartmentSharingLinks/{link_id}")
-    public String updateTokenStatus(@PathVariable("link_id") Long linkId, @PathVariable Long id, @RequestParam boolean enabled) {
-        List<Tenant> tenants = tenantService.findAllTenantsByApartmentSharingAndReorderDocumentsByCategory(id);
-        apartmentSharingLinkService.updateStatus(linkId, enabled, tenants.getFirst().getApartmentSharing());
+    public String updateTokenStatus(
+            @PathVariable("link_id") Long linkId,
+            @PathVariable Long id,
+            @RequestParam boolean enabled,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        ApartmentSharing apartmentSharing = applicationSharingService.findById(id).orElseThrow(BOAccessDenied::generic);
+
+        applicationAccessService.checkApartmentSharingAccess(principal, apartmentSharing.getId());
+        
+        apartmentSharingLinkService.updateStatus(linkId, enabled, apartmentSharing);
         return REDIRECT_BO_COLOCATION + id;
     }
 

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOMessageController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOMessageController.java
@@ -84,6 +84,7 @@ public class BOMessageController {
             @PathVariable("id") Long tenantId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        applicationAccessService.checkTenantAccess(principal, tenantId);
         return tenantService.updateStatusOfTenantFromAdmin(principal, messageDTO, tenantId);
     }
 

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
@@ -2,10 +2,10 @@ package fr.gouv.bo.controller;
 
 import fr.dossierfacile.common.entity.*;
 import fr.dossierfacile.common.enums.*;
-import fr.dossierfacile.common.exceptions.NotFoundException;
 import fr.dossierfacile.common.model.apartment_sharing.ApplicationModel;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.gouv.bo.dto.*;
+import fr.gouv.bo.security.BOAccessDenied;
 import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.*;
@@ -41,7 +41,6 @@ public class BOTenantController {
     private static final String CUSTOM_MESSAGE = "customMessage";
     private static final String CLARIFICATION = "clarification";
     private static final String OPERATOR_COMMENT = "operatorComment";
-    private static final String REDIRECT_ERROR = "redirect:/error";
 
     private final TenantService tenantService;
     private final MessageService messageService;
@@ -52,14 +51,16 @@ public class BOTenantController {
     private final TenantLogService logService;
     private final DocumentDeniedReasonsService documentDeniedReasonsService;
     private final BOApplicationAccessService applicationAccessService;
+    private final BOTenantResolver tenantResolver;
 
     @GetMapping("/{id}")
-    public String getTenant(@PathVariable Long id) {
-        Tenant tenant = tenantService.findTenantById(id);
-        if (tenant != null) {
-            return redirectToTenantPage(tenant);
-        }
-        throw new NotFoundException("Tenant is not found. Still exists?");
+    public String getTenant(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        Tenant tenant = requireTenant(id);
+        applicationAccessService.checkTenantAccess(principal, tenant.getId());
+        return redirectToTenantPage(tenant);
     }
 
     @PreAuthorize("hasRole('SUPPORT')")
@@ -68,7 +69,7 @@ public class BOTenantController {
             @PathVariable Long id,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Tenant tenant = tenantService.findTenantById(id);
+        Tenant tenant = requireTenant(id);
         if (tenant.getTenantType() == TenantType.CREATE) {
             throw new IllegalArgumentException("Delete main tenant is not allowed - set another user as main tenant before OR delete the entire apartmentSharing");
         }
@@ -84,7 +85,7 @@ public class BOTenantController {
             @AuthenticationPrincipal UserPrincipal principal,
             RedirectAttributes redirectAttributes
     ) {
-        Tenant tenant = tenantService.findTenantById(id);
+        Tenant tenant = requireTenant(id);
         BOUser operator = userService.findUserByEmail(principal.getEmail());
         Long apartmentSharingId = tenant.getApartmentSharing().getId();
         try {
@@ -102,7 +103,7 @@ public class BOTenantController {
             @PathVariable("id") Long id,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Tenant create = tenantService.findTenantById(id);
+        Tenant create = requireTenant(id);
         BOUser operator = userService.findUserByEmail(principal.getEmail());
         userService.deleteApartmentSharing(create, operator);
         return REDIRECT_BO_HOME;
@@ -111,7 +112,7 @@ public class BOTenantController {
     @PreAuthorize("hasRole('SUPPORT')")
     @PostMapping("/partner/{id}")
     public String sendCallbackToPartner(@PathVariable("id") Long id, PartnerDTO partnerDTO) {
-        Tenant tenant = tenantService.find(id);
+        Tenant tenant = requireTenant(id);
 
         UserApi userApi = userApiService.findById(partnerDTO.getPartner());
         PartnerCallBackType partnerCallBackType = tenant.getStatus() == TenantFileStatus.VALIDATED ?
@@ -129,6 +130,7 @@ public class BOTenantController {
             @PathVariable("id") Long tenantId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        requireTenant(tenantId);
         tenantService.validateTenantFile(principal, tenantId);
         return ok().build();
     }
@@ -139,6 +141,7 @@ public class BOTenantController {
             @PathVariable("id") Long tenantId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        requireTenant(tenantId);
         tenantService.declineTenant(principal, tenantId);
         return ok().build();
     }
@@ -149,6 +152,7 @@ public class BOTenantController {
             @PathVariable("id") Long tenantId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        requireTenant(tenantId);
         tenantService.reprocessTenant(principal, tenantId);
         return ok().build();
     }
@@ -159,6 +163,8 @@ public class BOTenantController {
             CustomMessage customMessage,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Tenant tenant = requireTenant(tenantId);
+        applicationAccessService.checkTenantAccess(principal, tenant.getId());
         return tenantService.customMessage(principal, tenantId, customMessage);
     }
 
@@ -168,6 +174,8 @@ public class BOTenantController {
             @PathVariable("id") Long id,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Tenant accessTenant = tenantResolver.resolveTenantFromDocument(id);
+        applicationAccessService.checkTenantAccess(principal, accessTenant.getId());
         User operator = userService.findUserByEmail(principal.getEmail());
         Tenant tenant = tenantService.deleteDocument(id, operator);
         return redirectToTenantPage(tenant);
@@ -179,6 +187,8 @@ public class BOTenantController {
             @PathVariable("id") Long fileId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Tenant accessTenant = tenantResolver.resolveTenantFromFile(fileId);
+        applicationAccessService.checkTenantAccess(principal, accessTenant.getId());
         User operator = userService.findUserByEmail(principal.getEmail());
         Tenant tenant = tenantService.deleteFile(fileId, operator);
         return redirectToTenantPage(tenant);
@@ -191,8 +201,7 @@ public class BOTenantController {
             MessageDTO messageDTO,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        Document document = documentService.findDocumentById(id);
-        Tenant accessTenant = document.getGuarantor() == null ? document.getTenant() : document.getGuarantor().getTenant();
+        Tenant accessTenant = tenantResolver.resolveTenantFromDocument(id);
         applicationAccessService.checkTenantAccess(principal, accessTenant.getId());
         User operator = userService.findUserByEmail(principal.getEmail());
         Tenant tenant = tenantService.changeDocumentStatus(id, messageDTO, operator);
@@ -203,13 +212,10 @@ public class BOTenantController {
     @GetMapping("/{id}/processFile")
     public String processFileForm(Model model, @PathVariable("id") Long id,
                                   @AuthenticationPrincipal UserPrincipal principal) {
-        applicationAccessService.checkTenantAccess(principal, id);
-        Tenant tenant = tenantService.find(id);
-
-        if (tenant == null) {
-            log.error("BOTenantController processFile not found tenant with id : {}", id);
-            return REDIRECT_ERROR;
-        }
+        
+        Tenant tenant = requireTenant(id);                            
+        applicationAccessService.checkTenantAccess(principal, tenant.getId());
+        
         List<TenantLog> logs = logService.getLogByTenantId(id);
         TenantInfoHeader header = TenantInfoHeader.build(tenant, userApiService.findPartnersLinkedToTenant(id), logs);
         List<TenantLog> modificationLogs = logs.stream()
@@ -233,6 +239,8 @@ public class BOTenantController {
             @PathVariable("guarantorId") Long guarantorId,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
+        Tenant accessTenant = tenantResolver.resolveTenantFromGuarantor(guarantorId);
+        applicationAccessService.checkTenantAccess(principal, accessTenant.getId());
         User operator = userService.findUserByEmail(principal.getEmail());
         Tenant tenant = tenantService.deleteGuarantor(guarantorId, operator);
         return redirectToTenantPage(tenant);
@@ -256,7 +264,9 @@ public class BOTenantController {
             CustomMessage customMessage,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        applicationAccessService.checkTenantAccess(principal, id);
+        Tenant tenant = requireTenant(id);
+        applicationAccessService.checkTenantAccess(principal, tenant.getId());
+        
         tenantService.processFile(id, customMessage, principal);
 
         // Si returnToHome est demandé, retourner à l'accueil
@@ -281,11 +291,24 @@ public class BOTenantController {
                                      @RequestParam String comment,
                                      @RequestParam(value = "returnTo", required = false) String returnTo,
                                      @AuthenticationPrincipal UserPrincipal principal) {
-        Tenant tenant = tenantService.addOperatorComment(principal, tenantId, comment);
+        
+        Tenant tenant = requireTenant(tenantId);
+        applicationAccessService.checkTenantAccess(principal, tenant.getId());
+        
+        tenantService.addOperatorComment(principal, tenant.getId(), comment);
         if ("processFile".equals(returnTo)) {
-            return REDIRECT_BO_HOME + "/tenant/" + tenantId + "/processFile";
+            return REDIRECT_BO_HOME + "/tenant/" + tenant.getId() + "/processFile";
         }
         return redirectToTenantPage(tenant);
+    }
+
+    private Tenant requireTenant(Long tenantId) {
+        Tenant tenant = tenantService.findTenantById(tenantId);
+        if (tenant == null) {
+            log.warn("BO access denied: tenant not found id={}", tenantId);
+            throw BOAccessDenied.generic();
+        }
+        return tenant;
     }
 
     private static String redirectToTenantPage(Tenant tenant) {

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/FileController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/FileController.java
@@ -4,11 +4,14 @@ import fr.dossierfacile.common.entity.StorageFile;
 import fr.dossierfacile.common.service.interfaces.FileStorageService;
 import fr.dossierfacile.common.service.interfaces.SharedFileService;
 import fr.gouv.bo.repository.DocumentRepository;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,6 +30,7 @@ public class FileController {
     private final DocumentRepository documentRepository;
     private final FileStorageService fileStorageService;
     private final SharedFileService fileService;
+    private final BOApplicationAccessService applicationAccessService;
 
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/files/{id}")
@@ -39,9 +43,14 @@ public class FileController {
 
     @PreAuthorize("hasRole('OPERATOR')")
     @GetMapping("/files/{id}/preview")
-    public void getPreviewFileAsByteArray(HttpServletResponse response, @PathVariable Long id) {
+    public void getPreviewFileAsByteArray(
+            HttpServletResponse response,
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
         fileService.findById(id).ifPresentOrElse(
                 file -> {
+                    applicationAccessService.checkFileAccess(principal, file);
                     if (file.getPreview() == null) {
                         response.setStatus(404);
                         return;

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOAccessDenied.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOAccessDenied.java
@@ -1,0 +1,15 @@
+package fr.gouv.bo.security;
+
+import org.springframework.security.access.AccessDeniedException;
+
+public final class BOAccessDenied {
+
+    public static final String GENERIC_MESSAGE = "Accès refusé";
+
+    private BOAccessDenied() {
+    }
+
+    public static AccessDeniedException generic() {
+        return new AccessDeniedException(GENERIC_MESSAGE);
+    }
+}

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java
@@ -1,5 +1,7 @@
 package fr.gouv.bo.security;
 
+import fr.dossierfacile.common.entity.File;
+
 public interface BOApplicationAccessService {
 
     /**
@@ -10,6 +12,15 @@ public interface BOApplicationAccessService {
      * No quota is enforced by this method (quota is checked at START_PROCESS time).
      */
     void checkTenantAccess(UserPrincipal principal, Long tenantId);
+
+    /**
+     * Checks that the principal is authorised to access a dossier identified by apartmentSharingId.
+     * For OPERATOR: requires a START_PROCESS or STOP_PROCESS log for any tenant of that apartment sharing
+     * in the configured assignment window.
+     * For SUPPORT / MANAGER / ADMIN: always authorised.
+     * Throws AccessDeniedException with a generic message if an OPERATOR is not assigned.
+     */
+    void checkApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId);
 
     /**
      * Checks that the principal is authorised to view a dossier identified by apartmentSharingId.
@@ -27,4 +38,12 @@ public interface BOApplicationAccessService {
      * Throws AccessDeniedException if the daily quota is reached.
      */
     void checkAndLogSearchTenant(UserPrincipal principal, String query, long resultCount);
+
+    /**
+     * Checks that the principal is authorised to access the dossier owning the given file.
+     * For OPERATOR: requires assignment to the resolved tenant in the configured window.
+     * For SUPPORT / MANAGER / ADMIN: always authorised.
+     * Throws AccessDeniedException if the file/document/tenant chain is broken or operator is not assigned.
+     */
+    void checkFileAccess(UserPrincipal principal, File file);
 }

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessServiceImpl.java
@@ -2,7 +2,9 @@ package fr.gouv.bo.security;
 
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import fr.dossierfacile.common.entity.File;
 import fr.dossierfacile.common.entity.OperatorLog;
+import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.entity.User;
 import fr.dossierfacile.common.enums.ActionOperatorType;
 import fr.dossierfacile.common.enums.TenantType;
@@ -10,11 +12,11 @@ import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.gouv.bo.repository.OperatorLogRepository;
 import fr.gouv.bo.service.QuotaService;
 import fr.gouv.bo.service.UserService;
+import fr.gouv.bo.service.BOTenantResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -32,38 +34,58 @@ public class BOApplicationAccessServiceImpl implements BOApplicationAccessServic
     private final TenantCommonRepository tenantRepository;
     private final UserService userService;
     private final QuotaService quotaService;
+    private final BOTenantResolver tenantResolver;
+
     @Value("${bo.assignment.access.window.days:7}")
     private int assignmentAccessWindowDays = 7;
 
     @Override
     public void checkTenantAccess(UserPrincipal principal, Long tenantId) {
         if (isOperatorOnly(principal)) {
-            LocalDateTime since = LocalDateTime.now().minusDays(assignmentAccessWindowDays);
-            boolean assigned = operatorLogRepository
-                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
-                            principal.getId(), tenantId, ASSIGNMENT_TYPES, since);
-            if (!assigned) {
-                log.warn("OPERATOR id={} attempted to access unassigned tenant id={}", principal.getId(), tenantId);
-                throw new AccessDeniedException(
-                        "OPERATOR " + principal.getId() + " is not assigned to tenant " + tenantId);
-            }
+            ensureOperatorAssignedToTenant(principal, tenantId);
+        }
+    }
+
+    @Override
+    public void checkApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId) {
+        if (isOperatorOnly(principal)) {
+            ensureOperatorAssignedToApartmentSharing(principal, apartmentSharingId);
         }
     }
 
     @Override
     public void checkAndLogApartmentSharingAccess(UserPrincipal principal, Long apartmentSharingId) {
-        if (isOperatorOnly(principal)) {
-            LocalDateTime since = LocalDateTime.now().minusDays(assignmentAccessWindowDays);
-            boolean assigned = operatorLogRepository.existsAssignmentForApartmentSharing(
-                    principal.getId(), apartmentSharingId, ASSIGNMENT_TYPES, since);
-            if (!assigned) {
-                log.warn("OPERATOR id={} attempted to access unassigned apartment sharing id={}", principal.getId(), apartmentSharingId);
-                throw new AccessDeniedException(
-                        "OPERATOR " + principal.getId() + " is not assigned to apartment sharing " + apartmentSharingId);
-            }
-        }
+        checkApartmentSharingAccess(principal, apartmentSharingId);
         quotaService.checkQuota(principal, ActionOperatorType.VIEW_APPLICATION);
         logViewApplicationForApartmentSharing(principal, apartmentSharingId);
+    }
+
+    @Override
+    public void checkFileAccess(UserPrincipal principal, File file) {
+        Tenant tenant = tenantResolver.resolveTenantFromFile(file);
+        checkTenantAccess(principal, tenant.getId());
+    }
+
+    private void ensureOperatorAssignedToTenant(UserPrincipal principal, Long tenantId) {
+        LocalDateTime since = LocalDateTime.now().minusDays(assignmentAccessWindowDays);
+        boolean assigned = operatorLogRepository
+                .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                        principal.getId(), tenantId, ASSIGNMENT_TYPES, since);
+        if (!assigned) {
+            log.warn("OPERATOR id={} attempted to access unassigned tenant id={}", principal.getId(), tenantId);
+            throw BOAccessDenied.generic();
+        }
+    }
+
+    private void ensureOperatorAssignedToApartmentSharing(UserPrincipal principal, Long apartmentSharingId) {
+        LocalDateTime since = LocalDateTime.now().minusDays(assignmentAccessWindowDays);
+        boolean assigned = operatorLogRepository.existsAssignmentForApartmentSharing(
+                principal.getId(), apartmentSharingId, ASSIGNMENT_TYPES, since);
+        if (!assigned) {
+            log.warn("OPERATOR id={} attempted to access unassigned apartment sharing id={}",
+                    principal.getId(), apartmentSharingId);
+            throw BOAccessDenied.generic();
+        }
     }
 
     @Override

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/service/BOTenantResolver.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/service/BOTenantResolver.java
@@ -1,0 +1,80 @@
+package fr.gouv.bo.service;
+import fr.dossierfacile.common.repository.SharedFileRepository;
+import fr.gouv.bo.repository.GuarantorRepository;
+import fr.gouv.bo.security.BOAccessDenied;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import fr.gouv.bo.exception.DocumentNotFoundException;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.Guarantor;
+import fr.dossierfacile.common.entity.Tenant;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BOTenantResolver {
+
+    private final SharedFileRepository sharedFileRepository;
+    private final GuarantorRepository guarantorRepository;
+    private final DocumentService documentService;
+
+    public Tenant resolveTenantFromFile(File file) {
+        Document document = file.getDocument();
+        if (document == null) {
+            log.warn("BO access denied: document missing for file id={}", file.getId());
+            throw BOAccessDenied.generic();
+        }
+        return resolveTenantFromDocument(document);
+    }
+
+    public Tenant resolveTenantFromFile(Long fileId) {
+        File file = sharedFileRepository.findById(fileId).orElse(null);
+        if (file == null) {
+            log.warn("BO access denied: file not found id={}", fileId);
+            throw BOAccessDenied.generic();
+        }
+        return resolveTenantFromFile(file);
+    }
+
+    public Tenant resolveTenantFromGuarantor(Guarantor guarantor) {
+        Tenant tenant = guarantor.getTenant();
+        if (tenant == null) {
+            log.warn("BO access denied: tenant missing for guarantor id={}",
+                    guarantor.getId());
+            throw BOAccessDenied.generic();
+        }
+        return tenant;
+    }
+
+    public Tenant resolveTenantFromGuarantor(Long guarantorId) {
+        Guarantor guarantor = guarantorRepository.findById(guarantorId).orElse(null);
+        if (guarantor == null) {
+            log.warn("BO access denied: guarantor not found id={}", guarantorId);
+            throw BOAccessDenied.generic();
+        }
+        return resolveTenantFromGuarantor(guarantor);
+    }
+
+    public Tenant resolveTenantFromDocument(Document document) {
+        Tenant tenant = document.getGuarantor() == null ? document.getTenant() : document.getGuarantor().getTenant();
+        if (tenant == null) {
+            log.warn("BO access denied: tenant missing for document id={}", document.getId());
+            throw BOAccessDenied.generic();
+        }
+        return tenant;
+    }
+
+    public Tenant resolveTenantFromDocument(Long documentId) {
+        Document document;
+        try {
+            document = documentService.findDocumentById(documentId);
+        } catch (DocumentNotFoundException e) {
+            log.warn("BO access denied: document not found id={}", documentId);
+            throw BOAccessDenied.generic();
+        }
+        return resolveTenantFromDocument(document);
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOApartmentSharingControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOApartmentSharingControllerTest.java
@@ -3,14 +3,20 @@ package fr.gouv.bo.controller;
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.ApartmentSharingLink;
 import fr.dossierfacile.common.entity.LinkLog;
+import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ApartmentSharingLinkType;
 import fr.dossierfacile.common.enums.LinkType;
 import fr.dossierfacile.common.repository.LinkLogRepository;
+import fr.dossierfacile.common.service.ApartmentSharingLinkService;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.gouv.bo.dto.ApartmentSharingLinkEnrichedDTO;
 import fr.gouv.bo.dto.LinkLogDTO;
+import fr.gouv.bo.security.BOAccessDenied;
 import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.DocumentService;
+import fr.gouv.bo.service.TenantLogService;
+import fr.gouv.bo.service.TenantService;
 import fr.gouv.bo.service.UserApiService;
 import fr.gouv.bo.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +33,7 @@ import org.springframework.ui.ExtendedModelMap;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,10 +50,10 @@ import static org.mockito.Mockito.when;
 class BOApartmentSharingControllerTest {
 
     @Mock
-    private LinkLogRepository linkLogRepository;
+    private TenantService tenantService;
 
     @Mock
-    private UserService userService;
+    private ApartmentSharingLinkService apartmentSharingLinkService;
 
     @Mock
     private UserApiService userApiService;
@@ -54,14 +62,34 @@ class BOApartmentSharingControllerTest {
     private DocumentService documentService;
 
     @Mock
+    private TenantLogService logService;
+
+    @Mock
+    private LinkLogRepository linkLogRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
     private BOApplicationAccessService applicationAccessService;
+
+    @Mock
+    private ApartmentSharingCommonService applicationSharingService;
 
     private BOApartmentSharingController controller;
 
     @BeforeEach
     void setUp() {
         controller = new BOApartmentSharingController(
-                null, null, userApiService, documentService, null, linkLogRepository, userService, applicationAccessService
+                tenantService,
+                apartmentSharingLinkService,
+                userApiService,
+                documentService,
+                logService,
+                linkLogRepository,
+                userService,
+                applicationAccessService,
+                applicationSharingService
         );
         ReflectionTestUtils.setField(controller, "tenantBaseUrl", "https://example.com");
     }
@@ -145,29 +173,102 @@ class BOApartmentSharingControllerTest {
         @Test
         void view_whenAccessServiceThrowsAccessDenied_propagatesException() {
             UserPrincipal principal = operatorPrincipal();
-            doThrow(new AccessDeniedException("forbidden"))
+            ApartmentSharing apartmentSharing = apartmentSharing(APARTMENT_SHARING_ID);
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.of(apartmentSharing));
+            doThrow(BOAccessDenied.generic())
                     .when(applicationAccessService)
                     .checkAndLogApartmentSharingAccess(any(), eq(APARTMENT_SHARING_ID));
 
             assertThatThrownBy(() -> controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal))
                     .isInstanceOf(AccessDeniedException.class)
-                    .hasMessage("forbidden");
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+
+        @Test
+        void view_whenApartmentSharingDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = supportPrincipal();
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(applicationAccessService, never()).checkAndLogApartmentSharingAccess(any(), any());
         }
 
         @Test
         void view_callsAccessServiceWithCorrectArguments() {
             UserPrincipal principal = supportPrincipal();
-            // Access service does nothing (no exception) — let the controller proceed;
-            // it will NPE on tenantService (null) after the access check, which is acceptable
-            // here since the goal is only to assert the access check is invoked first.
-            try {
-                controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal);
-            } catch (Exception ignored) {
-                // Expected: method continues past the access check but fails on null tenantService
-            }
+            ApartmentSharing apartmentSharing = apartmentSharing(APARTMENT_SHARING_ID);
+            Tenant tenant = new Tenant();
+            tenant.setApartmentSharing(apartmentSharing);
+            tenant.setDocuments(List.of());
+            tenant.setGuarantors(List.of());
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.of(apartmentSharing));
+            when(apartmentSharingLinkService.getFilteredLinks(apartmentSharing)).thenReturn(List.of());
+            when(tenantService.findAllTenantsByApartmentSharingAndReorderDocumentsByCategory(APARTMENT_SHARING_ID))
+                    .thenReturn(List.of(tenant));
+            when(userApiService.getAllPartners()).thenReturn(List.of());
 
+            String view = controller.view(new ExtendedModelMap(), APARTMENT_SHARING_ID, principal);
+
+            assertThat(view).isEqualTo("bo/apartment-sharing-view");
             verify(applicationAccessService).checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
         }
+    }
+
+    @Nested
+    class ApartmentSharingLinkEndpoints {
+
+        private static final Long APARTMENT_SHARING_ID = 99L;
+        private static final Long LINK_ID = 7L;
+
+        @Test
+        void deleteToken_whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            ApartmentSharing apartmentSharing = apartmentSharing(APARTMENT_SHARING_ID);
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.of(apartmentSharing));
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+
+            assertThatThrownBy(() -> controller.deleteToken(APARTMENT_SHARING_ID, LINK_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(apartmentSharingLinkService, never()).delete(any());
+        }
+
+        @Test
+        void deleteToken_whenAuthorized_deletesLinkAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            ApartmentSharing apartmentSharing = apartmentSharing(APARTMENT_SHARING_ID);
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.of(apartmentSharing));
+
+            String result = controller.deleteToken(APARTMENT_SHARING_ID, LINK_ID, principal);
+
+            assertThat(result).isEqualTo("redirect:/bo/colocation/99");
+            verify(applicationAccessService).checkApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+            verify(apartmentSharingLinkService).delete(LINK_ID);
+        }
+
+        @Test
+        void updateTokenStatus_whenApartmentSharingDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = supportPrincipal();
+            when(applicationSharingService.findById(APARTMENT_SHARING_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> controller.updateTokenStatus(LINK_ID, APARTMENT_SHARING_ID, true, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(applicationAccessService, never()).checkApartmentSharingAccess(any(), any());
+        }
+    }
+
+    private ApartmentSharing apartmentSharing(Long id) {
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setId(id);
+        return apartmentSharing;
     }
 
     private UserPrincipal operatorPrincipal() {

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
@@ -5,6 +5,7 @@ import fr.dossierfacile.common.entity.BOUser;
 import fr.dossierfacile.common.entity.Message;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.gouv.bo.dto.BrevoMailHistoryViewDTO;
+import fr.gouv.bo.dto.MessageDTO;
 import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.BrevoMailHistoryService;
@@ -132,6 +133,41 @@ class BOMessageControllerTest {
             controller.tenantBrevoHistory(new ExtendedModelMap(), TENANT_ID, principal);
 
             verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+        }
+    }
+
+    @Nested
+    class NewMessage {
+
+        private static final Long TENANT_ID = 10L;
+
+        @Test
+        void newMessage_whenAuthorized_checksAccessAndDelegatesToTenantService() {
+            UserPrincipal principal = operatorPrincipal();
+            MessageDTO messageDTO = MessageDTO.builder().message("Hello").build();
+            when(tenantService.updateStatusOfTenantFromAdmin(principal, messageDTO, TENANT_ID))
+                    .thenReturn("redirect:/bo/colocation/33#tenant10");
+
+            String result = controller.newMessage(messageDTO, TENANT_ID, principal);
+
+            assertThat(result).isEqualTo("redirect:/bo/colocation/33#tenant10");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).updateStatusOfTenantFromAdmin(principal, messageDTO, TENANT_ID);
+        }
+
+        @Test
+        void newMessage_whenAccessServiceThrowsAccessDenied_propagatesException() {
+            UserPrincipal principal = operatorPrincipal();
+            MessageDTO messageDTO = MessageDTO.builder().message("Hello").build();
+            doThrow(new AccessDeniedException("forbidden"))
+                    .when(applicationAccessService)
+                    .checkTenantAccess(any(), eq(TENANT_ID));
+
+            assertThatThrownBy(() -> controller.newMessage(messageDTO, TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage("forbidden");
+
+            verify(tenantService, never()).updateStatusOfTenantFromAdmin(any(), any(), any());
         }
     }
 

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOMessageControllerTest.java
@@ -6,6 +6,7 @@ import fr.dossierfacile.common.entity.Message;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.gouv.bo.dto.BrevoMailHistoryViewDTO;
 import fr.gouv.bo.dto.MessageDTO;
+import fr.gouv.bo.security.BOAccessDenied;
 import fr.gouv.bo.security.BOApplicationAccessService;
 import fr.gouv.bo.security.UserPrincipal;
 import fr.gouv.bo.service.BrevoMailHistoryService;
@@ -109,13 +110,13 @@ class BOMessageControllerTest {
         @Test
         void tenantBrevoHistory_whenAccessServiceThrowsAccessDenied_propagatesException() {
             UserPrincipal principal = operatorPrincipal();
-            doThrow(new AccessDeniedException("forbidden"))
+            doThrow(BOAccessDenied.generic())
                     .when(applicationAccessService)
                     .checkTenantAccess(any(), eq(TENANT_ID));
 
             assertThatThrownBy(() -> controller.tenantBrevoHistory(new ExtendedModelMap(), TENANT_ID, principal))
                     .isInstanceOf(AccessDeniedException.class)
-                    .hasMessage("forbidden");
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
 
             verify(brevoMailHistoryService, never()).getLast90DaysHistory(any());
         }
@@ -159,13 +160,13 @@ class BOMessageControllerTest {
         void newMessage_whenAccessServiceThrowsAccessDenied_propagatesException() {
             UserPrincipal principal = operatorPrincipal();
             MessageDTO messageDTO = MessageDTO.builder().message("Hello").build();
-            doThrow(new AccessDeniedException("forbidden"))
+            doThrow(BOAccessDenied.generic())
                     .when(applicationAccessService)
                     .checkTenantAccess(any(), eq(TENANT_ID));
 
             assertThatThrownBy(() -> controller.newMessage(messageDTO, TENANT_ID, principal))
                     .isInstanceOf(AccessDeniedException.class)
-                    .hasMessage("forbidden");
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
 
             verify(tenantService, never()).updateStatusOfTenantFromAdmin(any(), any(), any());
         }

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOTenantControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOTenantControllerTest.java
@@ -1,0 +1,452 @@
+package fr.gouv.bo.controller;
+
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.BOUser;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.TenantType;
+import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
+import fr.gouv.bo.dto.CustomMessage;
+import fr.gouv.bo.dto.MessageDTO;
+import fr.gouv.bo.security.BOAccessDenied;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
+import fr.gouv.bo.service.BOTenantResolver;
+import fr.gouv.bo.service.DocumentDeniedReasonsService;
+import fr.gouv.bo.service.DocumentService;
+import fr.gouv.bo.service.MessageService;
+import fr.gouv.bo.service.TenantLogService;
+import fr.gouv.bo.service.TenantService;
+import fr.gouv.bo.service.UserApiService;
+import fr.gouv.bo.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BOTenantControllerTest {
+
+    private static final Long TENANT_ID = 42L;
+    private static final Long APARTMENT_SHARING_ID = 99L;
+    private static final Long DOCUMENT_ID = 5L;
+    private static final Long FILE_ID = 12L;
+    private static final Long GUARANTOR_ID = 8L;
+
+    @Mock
+    private TenantService tenantService;
+    @Mock
+    private MessageService messageService;
+    @Mock
+    private DocumentService documentService;
+    @Mock
+    private UserApiService userApiService;
+    @Mock
+    private PartnerCallBackService partnerCallBackService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private TenantLogService logService;
+    @Mock
+    private DocumentDeniedReasonsService documentDeniedReasonsService;
+    @Mock
+    private BOApplicationAccessService applicationAccessService;
+    @Mock
+    private BOTenantResolver tenantResolver;
+
+    private BOTenantController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new BOTenantController(
+                tenantService,
+                messageService,
+                documentService,
+                userApiService,
+                partnerCallBackService,
+                userService,
+                logService,
+                documentDeniedReasonsService,
+                applicationAccessService,
+                tenantResolver
+        );
+    }
+
+    @Nested
+    class GetTenant {
+
+        @Test
+        void whenTenantDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(null);
+
+            assertThatThrownBy(() -> controller.getTenant(TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(applicationAccessService, never()).checkTenantAccess(any(), any());
+        }
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.getTenant(TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+
+        @Test
+        void whenOperatorAssigned_returnsRedirect() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+
+            String view = controller.getTenant(TENANT_ID, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+        }
+    }
+
+    @Nested
+    class DeleteDocument {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantResolver.resolveTenantFromDocument(DOCUMENT_ID)).thenReturn(accessTenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.deleteDocument(DOCUMENT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).deleteDocument(any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_deletesDocumentAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            BOUser operator = new BOUser();
+            when(tenantResolver.resolveTenantFromDocument(DOCUMENT_ID)).thenReturn(accessTenant);
+            when(userService.findUserByEmail(principal.getEmail())).thenReturn(operator);
+            when(tenantService.deleteDocument(DOCUMENT_ID, operator)).thenReturn(accessTenant);
+
+            String view = controller.deleteDocument(DOCUMENT_ID, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).deleteDocument(DOCUMENT_ID, operator);
+        }
+    }
+
+    @Nested
+    class DeleteFile {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantResolver.resolveTenantFromFile(FILE_ID)).thenReturn(accessTenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.deleteFile(FILE_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).deleteFile(any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_deletesFileAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            BOUser operator = new BOUser();
+            when(tenantResolver.resolveTenantFromFile(FILE_ID)).thenReturn(accessTenant);
+            when(userService.findUserByEmail(principal.getEmail())).thenReturn(operator);
+            when(tenantService.deleteFile(FILE_ID, operator)).thenReturn(accessTenant);
+
+            String view = controller.deleteFile(FILE_ID, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).deleteFile(FILE_ID, operator);
+        }
+    }
+
+    @Nested
+    class DeleteGuarantor {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantResolver.resolveTenantFromGuarantor(GUARANTOR_ID)).thenReturn(accessTenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.deleteGuarantor(GUARANTOR_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).deleteGuarantor(any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_deletesGuarantorAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            BOUser operator = new BOUser();
+            when(tenantResolver.resolveTenantFromGuarantor(GUARANTOR_ID)).thenReturn(accessTenant);
+            when(userService.findUserByEmail(principal.getEmail())).thenReturn(operator);
+            when(tenantService.deleteGuarantor(GUARANTOR_ID, operator)).thenReturn(accessTenant);
+
+            String view = controller.deleteGuarantor(GUARANTOR_ID, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).deleteGuarantor(GUARANTOR_ID, operator);
+        }
+    }
+
+    @Nested
+    class ChangeStatusOfDocument {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantResolver.resolveTenantFromDocument(DOCUMENT_ID)).thenReturn(accessTenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.changeStatusOfDocument(DOCUMENT_ID, new MessageDTO(), principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).changeDocumentStatus(any(), any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_changesStatusAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant accessTenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            BOUser operator = new BOUser();
+            MessageDTO messageDTO = MessageDTO.builder().message("ok").build();
+            when(tenantResolver.resolveTenantFromDocument(DOCUMENT_ID)).thenReturn(accessTenant);
+            when(userService.findUserByEmail(principal.getEmail())).thenReturn(operator);
+            when(tenantService.changeDocumentStatus(DOCUMENT_ID, messageDTO, operator)).thenReturn(accessTenant);
+
+            String view = controller.changeStatusOfDocument(DOCUMENT_ID, messageDTO, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).changeDocumentStatus(DOCUMENT_ID, messageDTO, operator);
+        }
+    }
+
+    @Nested
+    class CustomEmail {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.customEmail(TENANT_ID, new CustomMessage(), principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).customMessage(any(), any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_delegatesToTenantService() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            CustomMessage customMessage = new CustomMessage();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            when(tenantService.customMessage(principal, TENANT_ID, customMessage))
+                    .thenReturn("redirect:/bo/colocation/99#tenant42");
+
+            String view = controller.customEmail(TENANT_ID, customMessage, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+        }
+    }
+
+    @Nested
+    class ProcessFile {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.processFile(TENANT_ID, null, new CustomMessage(), principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).processFile(any(), any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_processesFileAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            CustomMessage customMessage = new CustomMessage();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            when(tenantService.findNextTenantInCouple(TENANT_ID)).thenReturn(Optional.empty());
+            when(tenantService.redirectToApplication(principal, null)).thenReturn("redirect:/bo");
+
+            String view = controller.processFile(TENANT_ID, null, customMessage, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).processFile(TENANT_ID, customMessage, principal);
+        }
+    }
+
+    @Nested
+    class AddOperatorComment {
+
+        @Test
+        void whenOperatorNotAssigned_throwsGenericAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkTenantAccess(principal, TENANT_ID);
+
+            assertThatThrownBy(() -> controller.addOperatorComment(TENANT_ID, "comment", null, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).addOperatorComment(any(), any(), any());
+        }
+
+        @Test
+        void whenOperatorAssigned_addsCommentAndRedirects() {
+            UserPrincipal principal = operatorPrincipal();
+            Tenant tenant = tenant(TENANT_ID, APARTMENT_SHARING_ID);
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant);
+
+            String view = controller.addOperatorComment(TENANT_ID, "comment", null, principal);
+
+            assertThat(view).isEqualTo("redirect:/bo/colocation/99#tenant42");
+            verify(applicationAccessService).checkTenantAccess(principal, TENANT_ID);
+            verify(tenantService).addOperatorComment(principal, TENANT_ID, "comment");
+        }
+    }
+
+    @Nested
+    class SupportTenantActions {
+
+        @Test
+        void validateTenantFile_whenTenantDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = supportPrincipal();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(null);
+
+            assertThatThrownBy(() -> controller.validateTenantFile(TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).validateTenantFile(any(), any());
+        }
+
+        @Test
+        void declineTenantFile_whenTenantDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = supportPrincipal();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(null);
+
+            assertThatThrownBy(() -> controller.declineTenantFile(TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).declineTenant(any(), any());
+        }
+
+        @Test
+        void reprocessTenantFile_whenTenantDoesNotExist_throwsGenericAccessDenied() {
+            UserPrincipal principal = supportPrincipal();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(null);
+
+            assertThatThrownBy(() -> controller.reprocessTenantFile(TENANT_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(tenantService, never()).reprocessTenant(any(), any());
+        }
+
+        @Test
+        void validateTenantFile_whenTenantExists_delegatesToService() {
+            UserPrincipal principal = supportPrincipal();
+            when(tenantService.findTenantById(TENANT_ID)).thenReturn(tenant(TENANT_ID, APARTMENT_SHARING_ID));
+
+            ResponseEntity<Void> response = controller.validateTenantFile(TENANT_ID, principal);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            verify(tenantService).validateTenantFile(principal, TENANT_ID);
+        }
+    }
+
+    private Tenant tenant(Long tenantId, Long apartmentSharingId) {
+        Tenant tenant = new Tenant();
+        tenant.setId(tenantId);
+        tenant.setTenantType(TenantType.CREATE);
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setId(apartmentSharingId);
+        tenant.setApartmentSharing(apartmentSharing);
+        return tenant;
+    }
+
+    private UserPrincipal operatorPrincipal() {
+        return new UserPrincipal(10L, "operator", "operator@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+    }
+
+    private UserPrincipal supportPrincipal() {
+        return new UserPrincipal(20L, "support", "support@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_SUPPORT")));
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/FileControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/FileControllerTest.java
@@ -1,0 +1,139 @@
+package fr.gouv.bo.controller;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.StorageFile;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.service.interfaces.FileStorageService;
+import fr.dossierfacile.common.service.interfaces.SharedFileService;
+import fr.gouv.bo.repository.DocumentRepository;
+import fr.gouv.bo.security.BOAccessDenied;
+import fr.gouv.bo.security.BOApplicationAccessService;
+import fr.gouv.bo.security.UserPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.io.ByteArrayInputStream;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileControllerTest {
+
+    private static final Long FILE_ID = 12L;
+    private static final Long TENANT_ID = 42L;
+
+    @Mock
+    private DocumentRepository documentRepository;
+    @Mock
+    private FileStorageService fileStorageService;
+    @Mock
+    private SharedFileService fileService;
+    @Mock
+    private BOApplicationAccessService applicationAccessService;
+
+    private FileController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new FileController(
+                documentRepository,
+                fileStorageService,
+                fileService,
+                applicationAccessService
+        );
+    }
+
+    @Nested
+    class GetPreviewFileAsByteArray {
+
+        @Test
+        void whenFileDoesNotExist_returns404() {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            when(fileService.findById(FILE_ID)).thenReturn(Optional.empty());
+
+            controller.getPreviewFileAsByteArray(response, FILE_ID, operatorPrincipal());
+
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+
+        @Test
+        void whenOperatorNotAssigned_throwsAccessDenied() {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileWithPreview();
+            when(fileService.findById(FILE_ID)).thenReturn(Optional.of(file));
+            doThrow(BOAccessDenied.generic())
+                    .when(applicationAccessService)
+                    .checkFileAccess(principal, file);
+
+            assertThatThrownBy(() -> controller.getPreviewFileAsByteArray(response, FILE_ID, principal))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+
+        @Test
+        void whenOperatorAssignedAndPreviewExists_streamsPreview() throws Exception {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileWithPreview();
+            when(fileService.findById(FILE_ID)).thenReturn(Optional.of(file));
+            when(fileStorageService.download(file.getPreview()))
+                    .thenReturn(new ByteArrayInputStream("preview".getBytes()));
+
+            controller.getPreviewFileAsByteArray(response, FILE_ID, principal);
+
+            verify(applicationAccessService).checkFileAccess(principal, file);
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.getContentType()).isEqualTo("image/jpeg");
+            assertThat(response.getContentAsByteArray()).isEqualTo("preview".getBytes());
+        }
+
+        @Test
+        void whenOperatorAssignedButPreviewMissing_returns404() {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileWithoutPreview();
+            when(fileService.findById(FILE_ID)).thenReturn(Optional.of(file));
+
+            controller.getPreviewFileAsByteArray(response, FILE_ID, principal);
+
+            verify(applicationAccessService).checkFileAccess(principal, file);
+            assertThat(response.getStatus()).isEqualTo(404);
+        }
+    }
+
+    private File fileWithPreview() {
+        Tenant tenant = new Tenant();
+        tenant.setId(TENANT_ID);
+        Document document = Document.builder().id(1L).tenant(tenant).build();
+        StorageFile preview = new StorageFile();
+        preview.setContentType("image/jpeg");
+        return File.builder().id(FILE_ID).document(document).preview(preview).build();
+    }
+
+    private File fileWithoutPreview() {
+        Tenant tenant = new Tenant();
+        tenant.setId(TENANT_ID);
+        Document document = Document.builder().id(1L).tenant(tenant).build();
+        return File.builder().id(FILE_ID).document(document).build();
+    }
+
+    private UserPrincipal operatorPrincipal() {
+        return new UserPrincipal(10L, "operator", "operator@test.com",
+                Set.of(new SimpleGrantedAuthority("ROLE_OPERATOR")));
+    }
+}

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/TaxDisplayTest.java
@@ -5,6 +5,7 @@ import fr.dossierfacile.common.enums.*;
 import fr.dossierfacile.common.enums.TypeGuarantor;
 import fr.dossierfacile.common.repository.LinkLogRepository;
 import fr.dossierfacile.common.service.ApartmentSharingLinkService;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.gouv.bo.TestBOApplication;
 import fr.gouv.bo.security.BOApplicationAccessService;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -86,12 +88,16 @@ class TaxDisplayTest {
     private DocumentDeniedReasonsService documentDeniedReasonsService;
     @MockitoBean
     private BOApplicationAccessService applicationAccessService;
+    @MockitoBean
+    private BOTenantResolver tenantResolver;
 
     // BOApartmentSharingController dependencies
     @MockitoBean
     private ApartmentSharingLinkService apartmentSharingLinkService;
     @MockitoBean
     private LinkLogRepository linkLogRepository;
+    @MockitoBean
+    private ApartmentSharingCommonService applicationSharingService;
 
     private Tenant tenant;
 
@@ -114,6 +120,7 @@ class TaxDisplayTest {
 
         // processFile mocks
         when(tenantService.find(1L)).thenReturn(tenant);
+        when(tenantService.findTenantById(1L)).thenReturn(tenant);
         when(logService.getLogByTenantId(anyLong())).thenReturn(Collections.emptyList());
         when(userApiService.findPartnersLinkedToTenant(anyLong())).thenReturn(Collections.emptyList());
         when(messageService.findTenantMessages(any())).thenReturn(Collections.emptyList());
@@ -133,6 +140,7 @@ class TaxDisplayTest {
         when(tenantService.hasVerifiedEmailIfExistsInKeycloak(any())).thenReturn(false);
         when(apartmentSharingLinkService.getFilteredLinks(any())).thenReturn(Collections.emptyList());
         when(userApiService.getAllPartners()).thenReturn(Collections.emptyList());
+        when(applicationSharingService.findById(1L)).thenReturn(Optional.of(tenant.getApartmentSharing()));
     }
 
     private Guarantor addGuarantor() {

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/security/BOApplicationAccessServiceTest.java
@@ -2,6 +2,9 @@ package fr.gouv.bo.security;
 
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.BOUser;
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.Guarantor;
 import fr.dossierfacile.common.entity.OperatorLog;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ActionOperatorType;
@@ -9,6 +12,8 @@ import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.gouv.bo.repository.OperatorLogRepository;
+import fr.gouv.bo.security.BOAccessDenied;
+import fr.gouv.bo.service.BOTenantResolver;
 import fr.gouv.bo.service.QuotaService;
 import fr.gouv.bo.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +51,7 @@ class BOApplicationAccessServiceTest {
     private TenantCommonRepository tenantRepository;
     private UserService userService;
     private QuotaService quotaService;
+    private BOTenantResolver tenantResolver;
 
     private BOApplicationAccessServiceImpl service;
 
@@ -55,7 +61,9 @@ class BOApplicationAccessServiceTest {
         tenantRepository = mock(TenantCommonRepository.class);
         userService = mock(UserService.class);
         quotaService = mock(QuotaService.class);
-        service = new BOApplicationAccessServiceImpl(operatorLogRepository, tenantRepository, userService, quotaService);
+        tenantResolver = mock(BOTenantResolver.class);
+        service = new BOApplicationAccessServiceImpl(
+                operatorLogRepository, tenantRepository, userService, quotaService, tenantResolver);
 
         // Default: tenant and operator exist
         Tenant tenant = buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID);
@@ -108,22 +116,8 @@ class BOApplicationAccessServiceTest {
                     .thenReturn(false);
 
             assertThatThrownBy(() -> service.checkTenantAccess(principal, TENANT_ID))
-                    .isInstanceOf(AccessDeniedException.class);
-
-            verify(operatorLogRepository, never()).save(any());
-        }
-
-        @Test
-        void operator_withAssignmentYesterday_throwsAccessDenied() {
-            UserPrincipal principal = operatorPrincipal();
-            // existsByOperatorId... returns false regardless of the date passed
-            when(operatorLogRepository
-                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
-                            anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
-                    .thenReturn(false);
-
-            assertThatThrownBy(() -> service.checkTenantAccess(principal, TENANT_ID))
-                    .isInstanceOf(AccessDeniedException.class);
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
 
             verify(operatorLogRepository, never()).save(any());
         }
@@ -194,8 +188,127 @@ class BOApplicationAccessServiceTest {
     }
 
     // -------------------------------------------------------------------------
+    // checkFileAccess
+    // -------------------------------------------------------------------------
+
+    @Nested
+    class CheckFileAccess {
+
+        @Test
+        void operator_withAssignmentToTenantFile_isAuthorized() {
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileForTenant(TENANT_ID);
+            when(tenantResolver.resolveTenantFromFile(file)).thenReturn(buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID));
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkFileAccess(principal, file);
+        }
+
+        @Test
+        void operator_withAssignmentToGuarantorTenantFile_isAuthorized() {
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileForGuarantor(TENANT_ID);
+            when(tenantResolver.resolveTenantFromFile(file)).thenReturn(buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID));
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            eq(OPERATOR_ID), eq(TENANT_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkFileAccess(principal, file);
+        }
+
+        @Test
+        void operator_withNoAssignment_throwsAccessDenied() {
+            UserPrincipal principal = operatorPrincipal();
+            File file = fileForTenant(TENANT_ID);
+            when(tenantResolver.resolveTenantFromFile(file)).thenReturn(buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID));
+            when(operatorLogRepository
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.checkFileAccess(principal, file))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+
+        @Test
+        void support_isAlwaysAuthorized() {
+            File file = fileForTenant(TENANT_ID);
+            when(tenantResolver.resolveTenantFromFile(file)).thenReturn(buildTenant(TENANT_ID, TenantType.CREATE, APARTMENT_SHARING_ID));
+
+            service.checkFileAccess(supportPrincipal(), file);
+
+            verify(operatorLogRepository, never())
+                    .existsByOperatorIdAndTenantIdAndActionOperatorTypeInAndCreationDateGreaterThanEqual(
+                            anyLong(), anyLong(), anyList(), any());
+        }
+
+        @Test
+        void fileWithoutDocument_throwsAccessDenied() {
+            File file = File.builder().id(1L).build();
+            when(tenantResolver.resolveTenantFromFile(file)).thenThrow(BOAccessDenied.generic());
+
+            assertThatThrownBy(() -> service.checkFileAccess(operatorPrincipal(), file))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // checkAndLogApartmentSharingAccess
     // -------------------------------------------------------------------------
+
+    @Nested
+    class CheckApartmentSharingAccess {
+
+        @Test
+        void operator_withAssignmentForTenantInSharing_isAuthorized() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository.existsAssignmentForApartmentSharing(
+                    eq(OPERATOR_ID), eq(APARTMENT_SHARING_ID), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(true);
+
+            service.checkApartmentSharingAccess(principal, APARTMENT_SHARING_ID);
+
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void operator_withNoAssignmentInSharing_throwsAccessDeniedAndNothingLogged() {
+            UserPrincipal principal = operatorPrincipal();
+            when(operatorLogRepository.existsAssignmentForApartmentSharing(
+                    anyLong(), anyLong(), anyList(), any(LocalDateTime.class)))
+                    .thenReturn(false);
+
+            assertThatThrownBy(() -> service.checkApartmentSharingAccess(principal, APARTMENT_SHARING_ID))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void support_isAlwaysAuthorized() {
+            service.checkApartmentSharingAccess(supportPrincipal(), APARTMENT_SHARING_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsAssignmentForApartmentSharing(anyLong(), anyLong(), anyList(), any());
+            verify(operatorLogRepository, never()).save(any());
+        }
+
+        @Test
+        void admin_isAlwaysAuthorized() {
+            service.checkApartmentSharingAccess(adminPrincipal(), APARTMENT_SHARING_ID);
+
+            verify(operatorLogRepository, never())
+                    .existsAssignmentForApartmentSharing(anyLong(), anyLong(), anyList(), any());
+            verify(operatorLogRepository, never()).save(any());
+        }
+    }
 
     @Nested
     class CheckAndLogApartmentSharingAccess {
@@ -220,7 +333,8 @@ class BOApplicationAccessServiceTest {
                     .thenReturn(false);
 
             assertThatThrownBy(() -> service.checkAndLogApartmentSharingAccess(principal, APARTMENT_SHARING_ID))
-                    .isInstanceOf(AccessDeniedException.class);
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
 
             verify(operatorLogRepository, never()).save(any());
         }
@@ -349,5 +463,18 @@ class BOApplicationAccessServiceTest {
         apartmentSharing.setId(apartmentSharingId);
         tenant.setApartmentSharing(apartmentSharing);
         return tenant;
+    }
+
+    private File fileForTenant(Long tenantId) {
+        Tenant tenant = buildTenant(tenantId, TenantType.CREATE, APARTMENT_SHARING_ID);
+        Document document = Document.builder().id(1L).tenant(tenant).build();
+        return File.builder().id(7L).document(document).build();
+    }
+
+    private File fileForGuarantor(Long tenantId) {
+        Tenant tenant = buildTenant(tenantId, TenantType.CREATE, APARTMENT_SHARING_ID);
+        Guarantor guarantor = Guarantor.builder().id(3L).tenant(tenant).build();
+        Document document = Document.builder().id(2L).guarantor(guarantor).build();
+        return File.builder().id(8L).document(document).build();
     }
 }

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/service/BOTenantResolverTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/service/BOTenantResolverTest.java
@@ -1,0 +1,198 @@
+package fr.gouv.bo.service;
+
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.entity.Guarantor;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.repository.SharedFileRepository;
+import fr.gouv.bo.exception.DocumentNotFoundException;
+import fr.gouv.bo.repository.GuarantorRepository;
+import fr.gouv.bo.security.BOAccessDenied;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BOTenantResolverTest {
+
+    private static final Long TENANT_ID = 42L;
+    private static final Long FILE_ID = 7L;
+    private static final Long DOCUMENT_ID = 1L;
+    private static final Long GUARANTOR_ID = 3L;
+
+    @Mock
+    private SharedFileRepository sharedFileRepository;
+
+    @Mock
+    private GuarantorRepository guarantorRepository;
+
+    @Mock
+    private DocumentService documentService;
+
+    private BOTenantResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new BOTenantResolver(sharedFileRepository, guarantorRepository, documentService);
+    }
+
+    @Nested
+    class ResolveTenantFromFileEntity {
+
+        @Test
+        void withDocumentAndTenant_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Document document = Document.builder().id(DOCUMENT_ID).tenant(tenant).build();
+            File file = File.builder().id(FILE_ID).document(document).build();
+
+            assertThat(resolver.resolveTenantFromFile(file)).isSameAs(tenant);
+        }
+
+        @Test
+        void withoutDocument_throwsAccessDenied() {
+            File file = File.builder().id(FILE_ID).build();
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromFile(file))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ResolveTenantFromFileId {
+
+        @Test
+        void whenFileExists_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Document document = Document.builder().id(DOCUMENT_ID).tenant(tenant).build();
+            File file = File.builder().id(FILE_ID).document(document).build();
+            when(sharedFileRepository.findById(FILE_ID)).thenReturn(Optional.of(file));
+
+            assertThat(resolver.resolveTenantFromFile(FILE_ID)).isSameAs(tenant);
+        }
+
+        @Test
+        void whenFileNotFound_throwsAccessDenied() {
+            when(sharedFileRepository.findById(FILE_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromFile(FILE_ID))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ResolveTenantFromGuarantorEntity {
+
+        @Test
+        void withTenant_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Guarantor guarantor = Guarantor.builder().id(GUARANTOR_ID).tenant(tenant).build();
+
+            assertThat(resolver.resolveTenantFromGuarantor(guarantor)).isSameAs(tenant);
+        }
+
+        @Test
+        void withoutTenant_throwsAccessDenied() {
+            Guarantor guarantor = Guarantor.builder().id(GUARANTOR_ID).build();
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromGuarantor(guarantor))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ResolveTenantFromGuarantorId {
+
+        @Test
+        void whenGuarantorExists_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Guarantor guarantor = Guarantor.builder().id(GUARANTOR_ID).tenant(tenant).build();
+            when(guarantorRepository.findById(GUARANTOR_ID)).thenReturn(Optional.of(guarantor));
+
+            assertThat(resolver.resolveTenantFromGuarantor(GUARANTOR_ID)).isSameAs(tenant);
+        }
+
+        @Test
+        void whenGuarantorNotFound_throwsAccessDenied() {
+            when(guarantorRepository.findById(GUARANTOR_ID)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromGuarantor(GUARANTOR_ID))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ResolveTenantFromDocumentEntity {
+
+        @Test
+        void withDirectTenant_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Document document = Document.builder().id(DOCUMENT_ID).tenant(tenant).build();
+
+            assertThat(resolver.resolveTenantFromDocument(document)).isSameAs(tenant);
+        }
+
+        @Test
+        void withGuarantorTenant_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Guarantor guarantor = Guarantor.builder().id(GUARANTOR_ID).tenant(tenant).build();
+            Document document = Document.builder().id(DOCUMENT_ID).guarantor(guarantor).build();
+
+            assertThat(resolver.resolveTenantFromDocument(document)).isSameAs(tenant);
+        }
+
+        @Test
+        void withoutTenant_throwsAccessDenied() {
+            Document document = Document.builder().id(DOCUMENT_ID).build();
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromDocument(document))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ResolveTenantFromDocumentId {
+
+        @Test
+        void whenDocumentExists_returnsTenant() {
+            Tenant tenant = tenant(TENANT_ID);
+            Document document = Document.builder().id(DOCUMENT_ID).tenant(tenant).build();
+            when(documentService.findDocumentById(DOCUMENT_ID)).thenReturn(document);
+
+            assertThat(resolver.resolveTenantFromDocument(DOCUMENT_ID)).isSameAs(tenant);
+        }
+
+        @Test
+        void whenDocumentNotFound_throwsAccessDenied() {
+            when(documentService.findDocumentById(DOCUMENT_ID)).thenThrow(new DocumentNotFoundException(DOCUMENT_ID));
+
+            assertThatThrownBy(() -> resolver.resolveTenantFromDocument(DOCUMENT_ID))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage(BOAccessDenied.GENERIC_MESSAGE);
+        }
+    }
+
+    private Tenant tenant(Long tenantId) {
+        Tenant tenant = new Tenant();
+        tenant.setId(tenantId);
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setId(99L);
+        tenant.setApartmentSharing(apartmentSharing);
+        return tenant;
+    }
+}


### PR DESCRIPTION
La branche `feat/fix-security-issues` ajoute un contrôle d'assignation OPERATOR systématique sur les opérations réalisées sur les entités tenant / apartment sharing / file, via :

[BOApplicationAccessService](https://github.com/MTES-MCT/dossierfacile-backend/compare/feat/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOApplicationAccessService.java) (2 nouvelles méthodes)

[BOTenantResolver](https://github.com/MTES-MCT/dossierfacile-backend/compare/feat/dossierfacile-bo/src/main/java/fr/gouv/bo/service/BOTenantResolver.java) (résolution File/Document/Guarantor → Tenant)

[BOAccessDenied](https://github.com/MTES-MCT/dossierfacile-backend/compare/feat/dossierfacile-bo/src/main/java/fr/gouv/bo/security/BOAccessDenied.java) (message d'erreur générique unique)

---

Mise en oeuvre des recommandations issues du test d'intrusion :
- Réduire la verbosité des messages d’erreurs permettant des mécanismes de découvrabilité des comptes utilisateurs
- Généraliser le contrôle d'accès opérateur à toutes les routes du BO