### PR TITLE
hotfix(bo): user can not disconnect from the bo

### DIFF
--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/configuration/WebSecurityConfig.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/configuration/WebSecurityConfig.java
@@ -90,7 +90,7 @@ public class WebSecurityConfig {
                 )
                 .logout(logout -> logout
                         .invalidateHttpSession(true)
-                        .deleteCookies("JSESSIONID", "JWT", "_csrf")
+                        .deleteCookies("SESSION", "JSESSIONID", "JWT", "_csrf")
                         .clearAuthentication(true)
                         .logoutSuccessHandler(oidcLogoutSuccessHandler(clientRegistrationRepository))
                 );

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/security/UserPrincipal.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/security/UserPrincipal.java
@@ -9,11 +9,16 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-public class UserPrincipal implements UserDetails, OidcUser {
+public class UserPrincipal implements UserDetails, OidcUser, Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     @Getter
     private final Long id;
     @Getter
@@ -25,7 +30,8 @@ public class UserPrincipal implements UserDetails, OidcUser {
     @Setter
     private transient Map<String, Object> attributes;
     // OIDC fields
-    private transient OidcIdToken oidcIdToken;
+    // Keep id token serializable in Redis-backed session so OIDC logout can call Keycloak end_session_endpoint.
+    private OidcIdToken oidcIdToken;
     private transient OidcUserInfo oidcUserInfo; // nullable
     private transient Map<String, Object> oidcClaims; // nullable
 

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/security/UserPrincipalSerializationTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/security/UserPrincipalSerializationTest.java
@@ -1,0 +1,58 @@
+package fr.gouv.bo.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class UserPrincipalSerializationTest {
+
+    @Test
+    void shouldKeepOidcIdTokenAfterSerialization() throws Exception {
+        UserPrincipal principal = new UserPrincipal(
+                1L,
+                "John",
+                "john.doe@example.com",
+                List.of(new SimpleGrantedAuthority("ROLE_OPERATOR"))
+        );
+
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token-value",
+                Instant.now(),
+                Instant.now().plusSeconds(3600),
+                Map.of("sub", "john-doe")
+        );
+        principal.setOidcData(idToken, null, null);
+
+        byte[] serialized = serialize(principal);
+        UserPrincipal deserialized = deserialize(serialized);
+
+        assertNotNull(deserialized.getIdToken());
+        assertEquals("id-token-value", deserialized.getIdToken().getTokenValue());
+    }
+
+    private static byte[] serialize(UserPrincipal principal) throws Exception {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(outputStream)) {
+            objectOutputStream.writeObject(principal);
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static UserPrincipal deserialize(byte[] bytes) throws Exception {
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            return (UserPrincipal) objectInputStream.readObject();
+        }
+    }
+}
+


### PR DESCRIPTION
Le point bloquant venait de UserPrincipal : le champ oidcIdToken était transient.
Avec Redis, la session est sérialisée/désérialisée, donc ce token était perdu entre requêtes.
Or OidcClientInitiatedLogoutSuccessHandler en a besoin pour appeler l’end_session_endpoint de Keycloak.