### PR TITLE
feat: link/mail sharing for completed dossier

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,83 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "TenantAPI",
+      "mainClass": "fr.dossierfacile.api.front.FrontApplication",
+      "projectName": "dossierfacile-api-tenant",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "Bo",
+      "mainClass": "fr.gouv.bo.BOApplication",
+      "projectName": "dossierfacile-bo",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "OwnerAPI",
+      "mainClass": "fr.dossierfacile.api.dossierfacileapiowner.DossierfacileApiOwnerApplication",
+      "projectName": "dossierfacile-api-owner",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "PDFGeneratorService",
+      "mainClass": "fr.dossierfacile.api.pdfgenerator.PdfGeneratorApplication",
+      "projectName": "dossierfacile-pdf-generator",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "TaskSchedulerService",
+      "mainClass": "fr.dossierfacile.scheduler.TaskSchedulerApplication",
+      "projectName": "dossierfacile-task-scheduler",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "java",
+      "request": "launch",
+      "name": "WatermarkApi",
+      "mainClass": "fr.dossierfacile.api.pdf.PdfApiApplication",
+      "projectName": "dossierfacile-api-watermark",
+      "args": "--spring.profiles.active=dev,mockOvh",
+      "cwd": "${workspaceFolder}"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Tenant+Bo",
+      "preLaunchTask": "docker-infra",
+      "configurations": [
+        "Bo",
+        "PDFGeneratorService",
+        "TaskSchedulerService",
+        "TenantAPI"
+      ]
+    },
+    {
+      "name": "AllInBabe",
+      "preLaunchTask": "docker-infra",
+      "configurations": [
+        "Bo",
+        "OwnerAPI",
+        "PDFGeneratorService",
+        "TaskSchedulerService",
+        "TenantAPI",
+        "WatermarkApi"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "docker-infra",
+      "detail": "Start local infra (postgres, rabbitmq, redis, nginx) + Keycloak",
+      "type": "shell",
+      "command": "docker compose -f docker-compose.dev.yml -f docker-compose.overwrite.yml up -d && docker compose -f ../Dossier-Facile-Keycloak/docker-compose.dev.yml up -d",
+      "options": { "cwd": "${workspaceFolder}" },
+      "presentation": { "reveal": "silent", "panel": "dedicated", "close": true },
+      "problemMatcher": []
+    },
+    {
+      "label": "docker-infra-down",
+      "detail": "Stop local infra + Keycloak",
+      "type": "shell",
+      "command": "docker compose -f docker-compose.dev.yml down && docker compose -f ../Dossier-Facile-Keycloak/docker-compose.dev.yml down",
+      "options": { "cwd": "${workspaceFolder}" },
+      "presentation": { "reveal": "always", "panel": "dedicated" },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/docs/completed-optin.md
+++ b/docs/completed-optin.md
@@ -2,17 +2,17 @@
 
 ## 1. Vue d'ensemble
 
-Le module **Opt-in COMPLETED** introduit un nouveau statut de dossier `COMPLETED` : un dossier complet et soumis (déclaration sur l'honneur signée), **utilisable immédiatement par le locataire sans vérification opérateur**. Le locataire ne peut le partager que par téléchargement ZIP des justificatifs filigranés ; les partages par lien, mail, espace propriétaire et DossierFacile Connect restent réservés aux dossiers `VALIDATED`.
+Le module **Opt-in COMPLETED** introduit un nouveau statut de dossier `COMPLETED` : un dossier complet et soumis (déclaration sur l'honneur signée), **utilisable immédiatement par le locataire sans vérification opérateur**. Le locataire peut le partager par téléchargement ZIP des justificatifs filigranés, ainsi que par lien et par mail (itération « partage COMPLETED » : page publique et full PDF au design « dossier complété, non vérifié », cf. §7.2) ; l'espace propriétaire et DossierFacile Connect restent réservés aux dossiers `VALIDATED`.
 
 Objectif : réduire la charge opérateur en laissant, par défaut, les dossiers éligibles hors de la file de traitement — la vérification devient un choix explicite du locataire.
 
 Ce système garantit :
 - **Un comportement strictement inchangé hors rollout** : la machine à états (`Tenant.computeStatus()`) n'est pas modifiée ; le passage en `COMPLETED` est une surcouche conditionnée par un feature flag.
-- **L'invisibilité totale du statut pour les partenaires** (DFC, api-partner, espace propriétaire) via quatre verrous complémentaires (§7).
+- **L'invisibilité totale du statut pour les partenaires** (DFC, api-partner, espace propriétaire) via trois verrous complémentaires (§7).
 - **Un seul fait persisté : le choix explicite de l'utilisateur** (`validation_requested`) — l'éligibilité est toujours recalculée, jamais stockée.
 - **Un rollback maîtrisé** : action BO explicite qui rebascule tous les dossiers `COMPLETED` en file de traitement.
 
-Périmètre MVP : dossiers **ALONE uniquement**, partage **ZIP uniquement**, rollout progressif démarré à 5 % (`only_for_new_user`).
+Périmètre MVP : dossiers **ALONE uniquement**, rollout progressif démarré à 5 % (`only_for_new_user`)
 
 ---
 
@@ -50,12 +50,11 @@ COMPLETED  ⟺  dossier complet + déclaration sur l'honneur signée
 Toujours **calculée à la volée, jamais stockée** (elle dépend d'états qui changent à tout moment). Conditions, évaluées de la moins chère à la plus chère :
 1. `application_type = ALONE` ;
 2. **aucune** ligne `tenant_userapi` — règle stricte : tout lien partenaire (DFC ou propriétaire via `dfconnect-proprietaire`), même résiduel après suppression de la candidature, désactive l'opt-in ;
-3. **jamais validé ni refusé** : `NOT EXISTS` sur `tenant_log` avec `log_type IN (ACCOUNT_VALIDATED, ACCOUNT_DENIED, ACCOUNT_AUTOMATICALLY_VALIDATED)` — inclut l'auto-validation : un dossier auto-validé Visale puis modifié a pu créer des liens de partage pendant sa période `VALIDATED` et ne doit jamais redevenir `COMPLETED` ;
-4. **en dernier** : `FeatureFlagService.isFeatureEnabledForUser(tenantId, "tenant_completed_optin")` — la première évaluation persiste l'assignation de bucket du user ; en le plaçant en dernier, seuls les candidats réels entrent dans le dénominateur des métriques, et les candidats hors rollout (`enabled = false`) forment le groupe contrôle.
+3. **en dernier** : `FeatureFlagService.isFeatureEnabledForUser(tenantId, "tenant_completed_optin")` — la première évaluation persiste l'assignation de bucket du user ; en le plaçant en dernier, seuls les candidats réels entrent dans le dénominateur des métriques, et les candidats hors rollout (`enabled = false`) forment le groupe contrôle.
 
 Deux méthodes publiques :
-- `isEligibleForOptIn(tenant)` : conditions 1-4 + dossier soumis (statut `TO_PROCESS` ou `COMPLETED`). Pilote l'affichage de la question côté front ; **indépendante de `validation_requested`** (la question reste modifiable après réponse).
-- `canBeCompleted(tenant)` : conditions 1-4 + `validation_requested ≠ true`. Utilisée pour l'attribution du statut `COMPLETED` ; l'appelant garantit que le statut calculé est `TO_PROCESS`.
+- `isEligibleForOptIn(tenant)` : conditions 1-3 + dossier soumis (statut `TO_PROCESS`, `COMPLETED`, `VALIDATED` ou `DECLINED`). Pilote l'affichage de la question côté front ; **indépendante de `validation_requested`** (la question reste modifiable après réponse). Sur un dossier `VALIDATED`/`DECLINED`, le choix est enregistré **sans effet immédiat sur le statut** : il s'applique à la prochaine re-soumission (UI dédiée à venir ; l'encart actuel ne s'affiche que pour `COMPLETED` et `TO_PROCESS` + demande en cours).
+- `canBeCompleted(tenant)` : conditions 1-3 + `validation_requested ≠ true`. Utilisée pour l'attribution du statut `COMPLETED` ; l'appelant garantit que le statut calculé est `TO_PROCESS`.
 
 ---
 
@@ -115,6 +114,8 @@ Deux méthodes publiques :
 | Modification du dossier | `computeStatus()` → `INCOMPLETE`, puis retour possible en `COMPLETED` à la re-signature | inchangé |
 | Changement de type ALONE → COUPLE/GROUP | purge + recalcul (§8) | remis à `null` |
 
+Toute sortie de `COMPLETED` invalide le full PDF (design « non vérifié », §7.2) via `resetDossierPdfGenerated` ; les liens de partage existants survivent.
+
 ---
 
 ## 6. Choix de l'utilisateur & exposition front
@@ -122,23 +123,24 @@ Deux méthodes publiques :
 - **`PUT /api/tenant/validation-request`** (scope `dossier`), body `{"validationRequested": true|false}` :
   - refuse (`409`) si `isEligibleForOptIn` est faux ;
   - persiste le choix, positionne `last_update_date = now`, journalise (`VALIDATION_REQUESTED` / `VALIDATION_DECLINED`), recalcule le statut ;
-  - si le dossier passe effectivement `COMPLETED → TO_PROCESS` (réponse « oui »), envoie le **template Brevo 56 existant** (« dossier complet, en attente de vérification ») — même situation qu'une soumission classique, aucun nouveau template.
+  - si le dossier passe effectivement `COMPLETED → TO_PROCESS` (réponse « oui »), envoie le **template Brevo 56 existant** (« dossier complet, en attente de vérification ») — même situation qu'une soumission classique, aucun nouveau template ;
+  - accepté aussi sur un dossier `VALIDATED` ou `DECLINED` : le recalcul de statut est alors un no-op (`computeStatus()` retourne le même statut), le choix est simplement enregistré pour la prochaine re-soumission.
 - **`TenantModel`** (profil locataire) expose :
   - `validationRequested` (`Boolean`, absent du JSON si `null` — jamais répondu) ;
-  - `optInEligible` (`boolean` primitif, toujours sérialisé) : pilote l'affichage de l'encart « Voulez-vous une validation opérateur ? » sur le tableau de bord.
+  - `optInEligible` (`boolean` primitif, toujours sérialisé) : pilote l'affichage de l'encart « Voulez-vous une validation opérateur ? » sur le tableau de bord. Vrai aussi pour les dossiers `VALIDATED`/`DECLINED` éligibles.
 - Les modèles partenaires (DFC, api-partner, api-owner) n'exposent **aucun** de ces champs.
 
 ---
 
-## 7. Invisibilité partenaires — les quatre verrous
+## 7. Invisibilité partenaires — les trois verrous
 
-Un dossier `COMPLETED` ne doit jamais être vu d'un partenaire (DFC, api-partner) ni d'un propriétaire. Quatre mécanismes complémentaires :
+Un dossier `COMPLETED` ne doit jamais être vu d'un partenaire (DFC, api-partner) ni d'un propriétaire. Trois mécanismes complémentaires (§7.1, §7.3, §7.4) — le §7.2 décrit le régime des liens de partage, qui ne créent aucun lien partenaire :
 
 ### 7.1 Bascule automatique à la liaison partenaire
 `PartnerCallBackServiceImpl.registerTenant()` — point de passage unique de toute création de lien `tenant_userapi` (connexion DFC, candidature propriétaire via `dfconnect-proprietaire`, propagation aux colocataires) — délègue à **`CompletedDossierService.switchBackToProcessing()`** (logique de bascule unique, partagée avec le rollback) : si le tenant est `COMPLETED`, il repasse `TO_PROCESS` **avant** l'envoi du callback (le webhook `CREATED_ACCOUNT` part donc avec un statut connu des partenaires), avec `last_update_date = now`, log `COMPLETED_SWITCHED_TO_PROCESS` et mail au locataire (template `brevo.template.id.completed.switched.to.processing`) après commit.
 
-### 7.2 Verrous de partage
-Le partage par lien/mail exige un dossier `VALIDATED` côté backend (`409` sinon) : `TenantServiceImpl.createSharingLink()`, `sendFileByMail()`, et `PUT /api/application/links/default`. Combiné à la règle « jamais validé → jamais COMPLETED » (§3.2), **aucun lien de partage ne peut coexister avec un dossier COMPLETED**. Le ZIP (`GET /api/application/zip`) reste, lui, accessible quel que soit le statut (comportement historique, canal de partage du MVP).
+### 7.2 Liens de partage & full PDF (itération « partage COMPLETED »)
+Le partage par lien/mail est ouvert aux dossiers `VALIDATED` **et** `COMPLETED` (`TenantFileStatus.isCompletedOrValidated()`, contrôlé par `TenantServiceImpl.requireCompletedOrValidatedDossier()` et `ApartmentSharingLinkController`, `409` sinon). Les liens LINK/MAIL peuvent donc coexister avec un dossier `COMPLETED` ; ils ne créent aucune ligne `tenant_userapi` et n'entament pas l'invisibilité partenaires. La page publique d'un dossier `COMPLETED` affiche un design « dossier complété, non vérifié par un agent » distinct du rendu `VALIDATED`. Le full PDF `COMPLETED` est un rendu neutre : uniquement les pages de justificatifs (pas de page de garde ni de « mot du locataire ») et sans les logos République Française / DossierFacile dans l'en-tête des pages ; le full PDF `VALIDATED` reste le rendu historique inchangé. La génération du full PDF exige un dossier `VALIDATED` ou `COMPLETED` avec tous les watermarks présents (`countTenantsBlockingFullPdfGeneration`, `417` sinon). À toute sortie de `COMPLETED` (opt-in « oui » §6, bascule partenaire §7.1, rollback §9), les liens **survivent** (la page publique bascule sur le rendu du nouveau statut) mais le full PDF est **invalidé** (`resetDossierPdfGenerated`) — il sera régénéré paresseusement au design du statut courant ; `complete()` (pdf-generator) jette par ailleurs tout fichier généré pendant une invalidation concurrente. Le ZIP (`GET /api/application/zip`) reste accessible quel que soit le statut.
 
 ### 7.3 Filet défensif dans les mappers
 `PartnerVisibleStatus.mask(status, source)` (common-library) : convertit `COMPLETED → TO_PROCESS` et émet un **`log.error`** — « *Defensive status masking triggered in {source}…* ». Ce cas ne doit jamais se produire : toute occurrence dans ELK signale un invariant cassé, à investiguer (les dossiers concernés se retrouvent via `status = 'COMPLETED' AND EXISTS tenant_userapi`). Branché dans six mappers :
@@ -217,7 +219,7 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 | A3 | Partage pendant TO_PROCESS | `/partages` sans formulaire ; bloc « documents non vérifiés » + ZIP OK ; après VALIDATED : création lien/mail OK |
 | A4 | COUPLE : signature | Les deux passent TO_PROCESS, mail au signataire seul (comportement actuel), pas d'encart |
 | A5 | Compte créé via partenaire DFC → funnel → signature | TO_PROCESS, webhook `CREATED_ACCOUNT`, pas d'encart |
-| A6 | Vérif SQL `user_feature_assignment` | Le user A1 (candidat réel) est assigné `enabled=false` (groupe contrôle) ; les users A4/A5 ne sont **pas** assignés (conditions 1-3 échouent avant le flag) |
+| A6 | Vérif SQL `user_feature_assignment` | Le user A1 (candidat réel) est assigné `enabled=false` (groupe contrôle) ; les users A4/A5 ne sont **pas** assignés (conditions 1-2 échouent avant le flag) |
 
 ### B. Dans le rollout (rollout 100 % en préprod)
 
@@ -225,13 +227,14 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 |---|---|---|
 | B1 | Funnel ALONE complet → signature | Statut `COMPLETED`, badge « Complété », mail template 173, encart affiché sans réponse (`validation_requested = null`) |
 | B2 | Dossier B1 côté BO | Absent de la file et des compteurs ; trouvable par recherche directe, libellé « complété » ; `processFile` impossible |
-| B3 | Partage B1 | Bloc ZIP visible + téléchargement OK ; `/partages` sans formulaire ; **appel API direct** `createSharingLink`/`sendFileByMail`/lien par défaut → 409 ; full PDF → 417 |
+| B3 | Partage B1 | ZIP OK ; création lien/mail et lien par défaut **OK** ; page publique au design « dossier complété, non vérifié » (badges info, documents consultables) ; full PDF généré paresseusement au design COMPLETED |
+| B3bis | Lien créé pendant B1 puis sortie de COMPLETED (opt-in « oui » ou liaison partenaire) | Le lien reste actif et la page publique bascule sur le rendu TO_PROCESS ; le full PDF est invalidé (409/417) puis régénéré au design du nouveau statut |
 | B4 | Encart : répondre « oui » | `validation_requested=true`, statut TO_PROCESS, entre en file (position = maintenant), badge « en cours », log `VALIDATION_REQUESTED`, mail template 56 reçu |
 | B5 | B4 puis annuler | Retour `COMPLETED`, `validation_requested=false`, sort de la file |
 | B6 | B1 → connexion à un partenaire DFC | Bascule immédiate TO_PROCESS, `validation_requested` reste `null`, mail de bascule, webhook `CREATED_ACCOUNT` avec `status=TO_PROCESS` (payload + `callback_log` : jamais COMPLETED), encart disparu, dossier en file |
 | B7 | B1 → candidature propriétaire (`/candidater/:token`) | Même bascule que B6 ; écran de confirmation owner = wording TO_PROCESS standard ; mail owner « candidat non validé », **pas** le « validé » |
 | B8 | B1 → modification d'un document | INCOMPLETE → re-signature → re-COMPLETED (choix inchangé, pas de nouvelle question) |
-| B9 | B4 → validé par un opérateur → modification d'un document | TO_PROCESS, **encart absent** (jamais re-COMPLETED : `tenant_log ACCOUNT_VALIDATED`) ; idem après un refus DECLINED corrigé |
+| B9 | B4 → validé par un opérateur → modification d'un document | Le choix `validation_requested=true` de B4 persiste → re-soumission en TO_PROCESS, **encart présent** (« annuler ma demande ») ; l'annulation bascule le dossier en COMPLETED. Un dossier examiné (validé ou refusé) dont le choix est `null`/`false` re-soumet **directement en COMPLETED** |
 | B10 | B1 → ajout d'un conjoint (ALONE → COUPLE) | `validation_requested` purgé, dossier INCOMPLETE ; après signature des deux → TO_PROCESS (plus ALONE), pas d'encart |
 | B11 | Compte rollout mais connecté DFC avant soumission | Signature → TO_PROCESS direct, mail 56 classique, pas d'encart |
 | B12 | Vérif exposition B1 | Profil : `optInEligible=true`, `validationRequested` absent ; `apartmentSharing.status` ≠ VALIDATED (tokens de partage absents du JSON) |
@@ -252,7 +255,7 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 ## 14. Limites du MVP & évolutions envisagées
 
 - **Colocs/couples exclus** (76-77 % du volume est ALONE) : l'extension passera par l'agrégat `ApartmentSharing.getStatus()` déjà en place (« pire statut gagne » : un seul tenant sans opt-in maintient le dossier global en `TO_PROCESS`).
-- **Partage ZIP uniquement** : l'ouverture des liens de partage aux dossiers `COMPLETED` demanderait un travail de wording/rebranding (page publique, PDF).
+- ~~**Partage ZIP uniquement**~~ : levé par l'itération « partage COMPLETED » (§7.2) — liens LINK/MAIL, page publique et full PDF au design dédié.
 - **Plafond journalier** : hors MVP ; réutilisera le statut `COMPLETED` comme second chemin d'entrée.
 - **Upgrade auto-validation** : laisser le bot Visale valider silencieusement les dossiers `COMPLETED` éligibles (coût opérateur nul, bénéfice usager).
 - Le **frontend** (badge, bloc ZIP, encart de choix — monorepo Dossier-Facile-Frontend) fait l'objet d'une PR séparée consommant `optInEligible` / `validationRequested` / `POST /api/tenant/validation-request`.

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkController.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkController.java
@@ -7,7 +7,6 @@ import fr.dossierfacile.api.front.security.interfaces.AuthenticationFacade;
 import fr.dossierfacile.api.front.service.interfaces.TenantService;
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
-import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.model.ApartmentSharingLinkModel;
 import fr.dossierfacile.common.service.ApartmentSharingLinkService;
 import io.swagger.annotations.ApiOperation;
@@ -50,12 +49,7 @@ public class ApartmentSharingLinkController {
     public ResponseEntity<ApartmentSharingLinkModel> updateApartmentSharingLinksStatus( @RequestParam boolean isFullData) {
         Tenant tenant = authenticationFacade.getLoggedTenant();
         ApartmentSharing apartmentSharing = tenant.getApartmentSharing();
-        // Sharing by link is reserved to fully validated dossiers (a COMPLETED dossier can only be shared as ZIP)
-        // TODO(completed-optin): allow COMPLETED here once link/mail sharing has been
-        // reworked to support non-verified dossiers
-        if (apartmentSharing.getStatus() != TenantFileStatus.VALIDATED) {
-            throw new TenantIllegalStateException("Sharing a dossier by link requires a validated dossier");
-        }
+        requireCompletedOrValidatedDossier(apartmentSharing);
         ApartmentSharingLinkModel defaultLink = apartmentSharingLinkService.getDefaultLink(apartmentSharing, tenant, isFullData);
         return ResponseEntity.ok(defaultLink);
     }
@@ -70,9 +64,6 @@ public class ApartmentSharingLinkController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateApartmentSharingLinksStatus(@PathVariable Long id, @RequestParam boolean enabled) {
         ApartmentSharing apartmentSharing = authenticationFacade.getLoggedTenant().getApartmentSharing();
-        if (enabled) {
-            requireNotCompletedDossier(apartmentSharing);
-        }
         apartmentSharingLinkService.updateStatus(id, enabled, apartmentSharing);
         return ResponseEntity.ok().build();
     }
@@ -87,7 +78,6 @@ public class ApartmentSharingLinkController {
     @PostMapping("/{id}/resend")
     public ResponseEntity<Void> resendApartmentSharingLink(@PathVariable Long id) {
         Tenant tenant = authenticationFacade.getLoggedTenant();
-        requireNotCompletedDossier(tenant.getApartmentSharing());
         tenantService.resendLink(id, tenant);
         return ResponseEntity.ok().build();
     }
@@ -123,15 +113,15 @@ public class ApartmentSharingLinkController {
     @PostMapping("/enableAll")
     public ResponseEntity<Void> enableAllLinks() {
         Tenant tenant = authenticationFacade.getLoggedTenant();
-        requireNotCompletedDossier(tenant.getApartmentSharing());
         apartmentSharingLinkService.enableValidLinks(tenant);
         return ResponseEntity.ok().build();
     }
 
-    // Defensing mechanism: a COMPLETED dossier cannot own any link
-    private void requireNotCompletedDossier(ApartmentSharing apartmentSharing) {
-        if (apartmentSharing != null && apartmentSharing.getStatus() == TenantFileStatus.COMPLETED) {
-            throw new TenantIllegalStateException("A completed dossier cannot be shared by link");
+    // Sharing by link is reserved to complete, submitted dossiers:
+    // VALIDATED (operator-verified) or COMPLETED (non verified, opt-in flow)
+    private void requireCompletedOrValidatedDossier(ApartmentSharing apartmentSharing) {
+        if (apartmentSharing == null || !apartmentSharing.getStatus().isCompletedOrValidated()) {
+            throw new TenantIllegalStateException("Sharing a dossier by link requires a validated or completed dossier");
         }
     }
 

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
@@ -183,13 +183,17 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
     @Override
     public void createFullPdf(UUID token) {
         ApartmentSharing apartmentSharing = findValidApartmentSharing(token, true);
+        requestFullPdfGeneration(apartmentSharing, token.toString());
+    }
 
-        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), token.toString());
+    // token is only used for logs and error reporting, null when the request does not come from a sharing link
+    private void requestFullPdfGeneration(ApartmentSharing apartmentSharing, String token) {
+        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), token);
 
         FileStatus pdfStatus = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
         switch (pdfStatus) {
-            case COMPLETED -> log.warn("Trying to create Full PDF on completed Status -" + token);
-            case IN_PROGRESS -> log.warn("Trying to create Full PDF on in progress Status -" + token);
+            case COMPLETED -> log.warn("Trying to create Full PDF on completed Status{}", token == null ? "" : " -" + token);
+            case IN_PROGRESS -> log.warn("Trying to create Full PDF on in progress Status{}", token == null ? "" : " -" + token);
             default -> {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
                 producer.generateFullPdf(apartmentSharing.getId());
@@ -298,18 +302,7 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
         if (apartmentSharing == null) {
             throw new ApartmentSharingNotFoundException("No apartment sharing found for tenant");
         }
-
-        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), null);
-
-        FileStatus pdfStatus = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
-        switch (pdfStatus) {
-            case COMPLETED -> log.warn("Trying to create Full PDF on completed Status");
-            case IN_PROGRESS -> log.warn("Trying to create Full PDF on in progress Status");
-            default -> {
-                apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
-                producer.generateFullPdf(apartmentSharing.getId());
-            }
-        }
+        requestFullPdfGeneration(apartmentSharing, null);
     }
 
 

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
@@ -184,10 +184,10 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
     public void createFullPdf(UUID token) {
         ApartmentSharing apartmentSharing = findValidApartmentSharing(token, true);
 
-        checkingAllTenantsInTheApartmentAreValidatedAndAllDocumentsAreNotNull(apartmentSharing.getId(), token.toString());
+        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), token.toString());
 
-        FileStatus status = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
-        switch (status) {
+        FileStatus pdfStatus = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
+        switch (pdfStatus) {
             case COMPLETED -> log.warn("Trying to create Full PDF on completed Status -" + token);
             case IN_PROGRESS -> log.warn("Trying to create Full PDF on in progress Status -" + token);
             default -> {
@@ -299,10 +299,10 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
             throw new ApartmentSharingNotFoundException("No apartment sharing found for tenant");
         }
 
-        checkingAllTenantsInTheApartmentAreValidatedAndAllDocumentsAreNotNull(apartmentSharing.getId(), null);
+        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), null);
 
-        FileStatus status = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
-        switch (status) {
+        FileStatus pdfStatus = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
+        switch (pdfStatus) {
             case COMPLETED -> log.warn("Trying to create Full PDF on completed Status");
             case IN_PROGRESS -> log.warn("Trying to create Full PDF on in progress Status");
             default -> {
@@ -400,8 +400,8 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
         zos.closeEntry();
     }
 
-    private void checkingAllTenantsInTheApartmentAreValidatedAndAllDocumentsAreNotNull(long apartmentSharingId, String token) {
-        int numberOfTenants = tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(apartmentSharingId);
+    private void checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(long apartmentSharingId, String token) {
+        int numberOfTenants = tenantRepository.countTenantsBlockingFullPdfGeneration(apartmentSharingId);
         if (numberOfTenants > 0) {
             if (token != null) {
                 throw new ApartmentSharingUnexpectedException(token);

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
@@ -25,6 +25,7 @@ import fr.dossierfacile.common.repository.ApartmentSharingLinkRepository;
 import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.LogService;
@@ -67,6 +68,7 @@ public class TenantServiceImpl implements TenantService {
     private final TenantMapperForMail tenantMapperForMail;
     private final CompletedEligibilityService completedEligibilityService;
     private final TenantStatusService tenantStatusService;
+    private final ApartmentSharingCommonService apartmentSharingCommonService;
 
     // There is a dependency cycle between TenantServiceImpl and TenantStatusService
     // (TenantStatusService -> ApartmentSharingService -> TenantPermissionsService -> TenantService),
@@ -86,7 +88,8 @@ public class TenantServiceImpl implements TenantService {
                              DocumentRepository documentRepository,
                              TenantMapperForMail tenantMapperForMail,
                              CompletedEligibilityService completedEligibilityService,
-                             @Lazy TenantStatusService tenantStatusService) {
+                             @Lazy TenantStatusService tenantStatusService,
+                             ApartmentSharingCommonService apartmentSharingCommonService) {
         this.apartmentSharingRepository = apartmentSharingRepository;
         this.apartmentSharingLinkRepository = apartmentSharingLinkRepository;
         this.confirmationTokenService = confirmationTokenService;
@@ -103,6 +106,7 @@ public class TenantServiceImpl implements TenantService {
         this.tenantMapperForMail = tenantMapperForMail;
         this.completedEligibilityService = completedEligibilityService;
         this.tenantStatusService = tenantStatusService;
+        this.apartmentSharingCommonService = apartmentSharingCommonService;
     }
 
     @Override
@@ -221,7 +225,7 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public void sendFileByMail(Tenant tenant, ShareFileByMailForm form) {
-        requireValidatedDossier(tenant);
+        requireCompletedOrValidatedDossier(tenant);
         UUID token = UUID.randomUUID();
         LocalDateTime date = LocalDateTime.now().minusDays(1);
         List<ApartmentSharingLink> existingASL = apartmentSharingLinkRepository.findByApartmentSharingAndCreationDateIsAfterAndDeletedIsFalse(tenant.getApartmentSharing(), date);
@@ -255,7 +259,7 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public String createSharingLink(Tenant tenant, ShareFileByLinkForm form) {
-        requireValidatedDossier(tenant);
+        requireCompletedOrValidatedDossier(tenant);
         UUID token = UUID.randomUUID();
         ApartmentSharingLink apartmentSharingLink = ApartmentSharingLink.builder()
                 .apartmentSharing(tenant.getApartmentSharing())
@@ -273,13 +277,10 @@ public class TenantServiceImpl implements TenantService {
         return path + token;
     }
 
-    // Sharing by link or mail is reserved to fully validated dossiers. This backend
-    // check guarantees a COMPLETED (non verified) dossier can only be shared as ZIP.
-    // TODO(completed-optin): allow COMPLETED here once link/mail sharing (public page,
-    // full PDF, wording) has been reworked to support non-verified dossiers
-    private void requireValidatedDossier(Tenant tenant) {
-        if (tenant.getApartmentSharing().getStatus() != TenantFileStatus.VALIDATED) {
-            throw new TenantIllegalStateException("Sharing a dossier by link or mail requires a validated dossier");
+    // Sharing by link or mail is reserved to VALIDATED or COMPLETED dossiers
+    private void requireCompletedOrValidatedDossier(Tenant tenant) {
+        if (!tenant.getApartmentSharing().getStatus().isCompletedOrValidated()) {
+            throw new TenantIllegalStateException("Sharing a dossier by link or mail requires a validated or completed dossier");
         }
     }
 
@@ -291,11 +292,18 @@ public class TenantServiceImpl implements TenantService {
         }
         TenantFileStatus previousStatus = tenant.getStatus();
         tenant.setValidationRequested(validationRequested);
-        // Queue position is based on the moment of the choice
+        // Queue position is based on the moment of the choice (harmless when the
+        // dossier is VALIDATED or DECLINED: it is not in the TO_PROCESS queue and
+        // the choice only applies to the next re-submission)
         tenant.setLastUpdateDate(LocalDateTime.now(ZoneId.systemDefault()));
         tenantRepository.save(tenant);
         logService.saveLog(validationRequested ? LogType.VALIDATION_REQUESTED : LogType.VALIDATION_DECLINED, tenant.getId());
         Tenant updatedTenant = tenantStatusService.updateTenantStatus(tenant);
+        if (previousStatus == TenantFileStatus.COMPLETED && updatedTenant.getStatus() != TenantFileStatus.COMPLETED) {
+            // The full PDF was rendered with the COMPLETED design: it must not
+            // survive the switch out of COMPLETED
+            apartmentSharingCommonService.resetDossierPdfGenerated(updatedTenant.getApartmentSharing());
+        }
         // Entering the verification queue: reuse the standard "waiting for review" email
         if (validationRequested && previousStatus == TenantFileStatus.COMPLETED
                 && updatedTenant.getStatus() == TenantFileStatus.TO_PROCESS) {

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkControllerTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkControllerTest.java
@@ -7,6 +7,9 @@ import fr.dossierfacile.api.front.service.interfaces.TenantService;
 import fr.dossierfacile.common.config.GlobalExceptionHandler;
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.ApplicationType;
+import fr.dossierfacile.common.enums.TenantFileStatus;
+import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.exceptions.NotFoundException;
 import fr.dossierfacile.common.model.ApartmentSharingLinkModel;
 import fr.dossierfacile.common.service.ApartmentSharingLinkService;
@@ -33,6 +36,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import javax.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -72,6 +76,96 @@ public class ApartmentSharingLinkControllerTest {
     @PostConstruct
     void setSelf() {
         self = this;
+    }
+
+    private static ApartmentSharing apartmentSharingWithStatus(TenantFileStatus status) {
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setApplicationType(ApplicationType.ALONE);
+        Tenant tenant = new Tenant();
+        tenant.setTenantType(TenantType.CREATE);
+        tenant.setStatus(status);
+        tenant.setApartmentSharing(apartmentSharing);
+        apartmentSharing.setTenants(new ArrayList<>(List.of(tenant)));
+        return apartmentSharing;
+    }
+
+    private static Tenant tenantWithDossierStatus(TenantFileStatus status) {
+        return apartmentSharingWithStatus(status).getTenants().get(0);
+    }
+
+    @Nested
+    class UpdateDefaultLinkTests {
+
+        record UpdateDefaultLinkTestParameter() {
+        }
+
+        static List<Arguments> provideUpdateDefaultLinkParameters() {
+
+            SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor jwtTokenWithDossier = jwt().authorities(new SimpleGrantedAuthority("SCOPE_dossier"));
+
+            return ArgumentBuilder.buildListOfArguments(
+                    Pair.of("Should respond 401 when no jwt is passed",
+                            new ControllerParameter<>(
+                                    new UpdateDefaultLinkTestParameter(),
+                                    401,
+                                    null,
+                                    null,
+                                    Collections.emptyList()
+                            )
+                    ),
+                    Pair.of("Should respond 200 when dossier is VALIDATED",
+                            new ControllerParameter<>(
+                                    new UpdateDefaultLinkTestParameter(),
+                                    200,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.VALIDATED));
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
+                    ),
+                    Pair.of("Should respond 200 when dossier is COMPLETED",
+                            new ControllerParameter<>(
+                                    new UpdateDefaultLinkTestParameter(),
+                                    200,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.COMPLETED));
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
+                    ),
+                    Pair.of("Should respond 409 when dossier is neither COMPLETED nor VALIDATED",
+                            new ControllerParameter<>(
+                                    new UpdateDefaultLinkTestParameter(),
+                                    409,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.TO_PROCESS));
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
+                    )
+            );
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("provideUpdateDefaultLinkParameters")
+        void parameterizedTests(ControllerParameter<UpdateDefaultLinkTestParameter> parameter) throws Exception {
+
+            var mockMvcRequestBuilder = put("/api/application/links/default")
+                    .param("isFullData", "true")
+                    .contentType("application/json");
+
+            ParameterizedTestHelper.runControllerTest(
+                    mockMvc,
+                    mockMvcRequestBuilder,
+                    parameter
+            );
+        }
     }
 
     @Nested
@@ -231,6 +325,18 @@ public class ApartmentSharingLinkControllerTest {
                                     },
                                     Collections.emptyList()
                             )
+                    ),
+                    Pair.of("Should respond 200 when enabling a link on a COMPLETED dossier",
+                            new ControllerParameter<>(
+                                    new UpdateApartmentSharingLinksStatusTestParameter(1L, true),
+                                    200,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.COMPLETED));
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
                     )
             );
         }
@@ -353,6 +459,18 @@ public class ApartmentSharingLinkControllerTest {
                                     jwtTokenWithDossier,
                                     (v) -> {
                                         when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenant);
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
+                    ),
+                    Pair.of("Should respond 200 when resending a link on a COMPLETED dossier",
+                            new ControllerParameter<>(
+                                    new ResendApartmentSharingLinkTestParameter(),
+                                    200,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.COMPLETED));
                                         return v;
                                     },
                                     Collections.emptyList()

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import fr.dossierfacile.common.enums.DocumentSubCategory;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.FileStorageService;
@@ -100,6 +101,8 @@ class DfcTenantsControllerIntegrationTest {
     private CompletedEligibilityService completedEligibilityService;
     @MockitoBean
     private TenantStatusService tenantStatusService;
+    @MockitoBean
+    private ApartmentSharingCommonService apartmentSharingCommonService;
 
     private Long tenantId;
     private String expectedDocumentUrl;

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImplTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImplTest.java
@@ -180,7 +180,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldThrowExceptionButStillTriggerPdfCreation() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 assertThrows(IllegalStateException.class, () ->
                         apartmentSharingService.downloadFullPdfForTenant(tenant)
@@ -195,7 +195,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldThrowExceptionButStillTriggerPdfCreation() {
                 apartmentSharing.setDossierPdfDocumentStatus(null);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 assertThrows(IllegalStateException.class, () ->
                         apartmentSharingService.downloadFullPdfForTenant(tenant)
@@ -226,7 +226,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldNotTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.COMPLETED);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 apartmentSharingService.createFullPdfForTenant(tenant);
 
@@ -239,7 +239,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldNotTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.IN_PROGRESS);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 apartmentSharingService.createFullPdfForTenant(tenant);
 
@@ -252,7 +252,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 apartmentSharingService.createFullPdfForTenant(tenant);
 
@@ -265,7 +265,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(null);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
 
                 apartmentSharingService.createFullPdfForTenant(tenant);
 
@@ -279,7 +279,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldNotTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(1);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(1);
 
                 assertThrows(ApartmentSharingUnexpectedException.class, () ->
                         apartmentSharingService.createFullPdfForTenant(tenant)
@@ -294,7 +294,7 @@ class ApartmentSharingServiceImplTest {
             @Test
             void shouldNotTriggerPdfGeneration() {
                 apartmentSharing.setDossierPdfDocumentStatus(FileStatus.NONE);
-                when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(2);
+                when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(2);
 
                 assertThrows(ApartmentSharingUnexpectedException.class, () ->
                         apartmentSharingService.createFullPdfForTenant(tenant)

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
@@ -1,22 +1,31 @@
 package fr.dossierfacile.api.front.service;
 
+import fr.dossierfacile.api.front.exception.TenantIllegalStateException;
+import fr.dossierfacile.api.front.form.ShareFileByLinkForm;
+import fr.dossierfacile.api.front.form.ShareFileByMailForm;
 import fr.dossierfacile.api.front.register.RegisterFactory;
 import fr.dossierfacile.api.front.repository.DocumentRepository;
 import fr.dossierfacile.api.front.service.interfaces.DocumentService;
 import fr.dossierfacile.api.front.service.interfaces.KeycloakService;
 import fr.dossierfacile.api.front.service.interfaces.MailService;
+import fr.dossierfacile.api.front.service.interfaces.TenantStatusService;
 import fr.dossierfacile.api.front.service.interfaces.UserApiService;
 import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.ApartmentSharingLink;
 import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.DocumentAnalysisReport;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ApplicationType;
+import fr.dossierfacile.common.enums.LogType;
+import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.repository.ApartmentSharingLinkRepository;
 import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.LogService;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
@@ -26,12 +35,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,6 +76,12 @@ class TenantServiceImplTest {
     private DocumentService documentService;
     @Mock
     private DocumentRepository documentRepository;
+    @Mock
+    private CompletedEligibilityService completedEligibilityService;
+    @Mock
+    private TenantStatusService tenantStatusService;
+    @Mock
+    private ApartmentSharingCommonService apartmentSharingCommonService;
 
     @InjectMocks
     private TenantServiceImpl tenantService;
@@ -184,6 +201,142 @@ class TenantServiceImplTest {
 
         verify(documentAnalysisReportRepository, times(1)).save(reportOnCreate);
         assertEquals("Secondary commenting primary", reportOnCreate.getComment());
+    }
+
+    private Tenant aloneTenantWithStatus(TenantFileStatus status) {
+        ApartmentSharing sharing = new ApartmentSharing();
+        sharing.setId(2L);
+        sharing.setApplicationType(ApplicationType.ALONE);
+        sharing.setTenants(new ArrayList<>());
+
+        Tenant tenant = new Tenant();
+        tenant.setId(20L);
+        tenant.setTenantType(TenantType.CREATE);
+        tenant.setStatus(status);
+        tenant.setApartmentSharing(sharing);
+        sharing.getTenants().add(tenant);
+        return tenant;
+    }
+
+    @Test
+    void createSharingLink_isAllowedForValidatedDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.VALIDATED);
+        ShareFileByLinkForm form = ShareFileByLinkForm.builder().title("Agence").fullData(true).daysValid(30).build();
+
+        String url = tenantService.createSharingLink(tenant, form);
+
+        assertTrue(url.startsWith("/file/"));
+        verify(apartmentSharingLinkRepository).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
+    void createSharingLink_isAllowedForCompletedDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
+        ShareFileByLinkForm form = ShareFileByLinkForm.builder().title("Agence").fullData(false).daysValid(30).build();
+
+        String url = tenantService.createSharingLink(tenant, form);
+
+        assertTrue(url.startsWith("/public-file/"));
+        verify(apartmentSharingLinkRepository).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
+    void createSharingLink_isRefusedForNonCompletedOrValidatedDossier() {
+        for (TenantFileStatus status : new TenantFileStatus[]{
+                TenantFileStatus.TO_PROCESS, TenantFileStatus.INCOMPLETE, TenantFileStatus.DECLINED}) {
+            Tenant tenant = aloneTenantWithStatus(status);
+            ShareFileByLinkForm form = ShareFileByLinkForm.builder().title("Agence").daysValid(30).build();
+
+            assertThrows(TenantIllegalStateException.class, () -> tenantService.createSharingLink(tenant, form));
+        }
+        verify(apartmentSharingLinkRepository, never()).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
+    void sendFileByMail_isAllowedForCompletedDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
+        when(apartmentSharingLinkRepository.findByApartmentSharingAndCreationDateIsAfterAndDeletedIsFalse(any(), any()))
+                .thenReturn(new ArrayList<>());
+        ShareFileByMailForm form = ShareFileByMailForm.builder()
+                .email("owner@example.com").title("Agence").message("Bonjour").fullData(true).daysValid(7).build();
+
+        tenantService.sendFileByMail(tenant, form);
+
+        verify(mailService).sendFileByMail(startsWith("/file/"), eq("owner@example.com"), eq("Bonjour"), any(), any(), any());
+        verify(apartmentSharingLinkRepository).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
+    void sendFileByMail_isRefusedForNonCompletedOrValidatedDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.TO_PROCESS);
+        ShareFileByMailForm form = ShareFileByMailForm.builder()
+                .email("owner@example.com").title("Agence").message("Bonjour").daysValid(7).build();
+
+        assertThrows(TenantIllegalStateException.class, () -> tenantService.sendFileByMail(tenant, form));
+        verifyNoInteractions(mailService);
+    }
+
+    @Test
+    void updateValidationRequest_resetsFullPdf_whenDossierLeavesCompleted() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(tenantStatusService.updateTenantStatus(tenant)).thenAnswer(invocation -> {
+            tenant.setStatus(TenantFileStatus.TO_PROCESS);
+            return tenant;
+        });
+        TransactionSynchronizationManager.initSynchronization();
+
+        try {
+            tenantService.updateValidationRequest(tenant, true);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+
+        // The full PDF was rendered with the "non verified" design and must be dropped
+        verify(apartmentSharingCommonService).resetDossierPdfGenerated(tenant.getApartmentSharing());
+    }
+
+    @Test
+    void updateValidationRequest_keepsFullPdf_whenDossierStaysCompleted() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
+
+        tenantService.updateValidationRequest(tenant, false);
+
+        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
+    }
+
+    // On a reviewed dossier the choice is recorded without any immediate effect:
+    // it only applies to the next re-submission
+    @Test
+    void updateValidationRequest_onValidatedDossier_persistsChoiceWithoutTouchingStatusOrPdf() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.VALIDATED);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
+
+        Tenant updated = tenantService.updateValidationRequest(tenant, false);
+
+        assertEquals(TenantFileStatus.VALIDATED, updated.getStatus());
+        assertEquals(Boolean.FALSE, updated.getValidationRequested());
+        verify(logService).saveLog(LogType.VALIDATION_DECLINED, tenant.getId());
+        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
+        verifyNoInteractions(mailService);
+    }
+
+    @Test
+    void updateValidationRequest_onDeclinedDossier_persistsChoiceWithoutTouchingStatus() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.DECLINED);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
+
+        Tenant updated = tenantService.updateValidationRequest(tenant, true);
+
+        assertEquals(TenantFileStatus.DECLINED, updated.getStatus());
+        assertEquals(Boolean.TRUE, updated.getValidationRequested());
+        verify(logService).saveLog(LogType.VALIDATION_REQUESTED, tenant.getId());
+        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
+        verifyNoInteractions(mailService);
     }
 
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/TenantFileStatus.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/TenantFileStatus.java
@@ -19,4 +19,13 @@ public enum TenantFileStatus {
     public String getLabel() {
         return label;
     }
+
+    /**
+     * A dossier can be shared by link or mail once complete and submitted:
+     * either verified by an operator (VALIDATED) or completed without
+     * operator verification (COMPLETED).
+     */
+    public boolean isCompletedOrValidated() {
+        return this == VALIDATED || this == COMPLETED;
+    }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
@@ -219,14 +219,28 @@ public interface TenantCommonRepository extends JpaRepository<Tenant, Long> {
     )
     List<Tenant> findAllDeclinedSinceXDaysAgo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
-    // The full dossier PDF can only be generated for COMPLETED or VALIDATED dossiers
-    // whose documents all have their watermarked file available
+    // The full dossier PDF can only be generated for COMPLETED or VALIDATED dossiers whose documents
+    // (including guarantor ones) all have their watermarked file available
     @Query(value = """
             SELECT COUNT(t.id)
             FROM tenant t
-            LEFT JOIN document d ON d.tenant_id = t.id OR d.guarantor_id = t.id
             WHERE t.apartment_sharing_id = :apartmentSharingId
-              AND ( t.status NOT IN ('VALIDATED', 'COMPLETED') OR d.watermark_file_id IS NULL )
+              AND (
+                t.status NOT IN ('VALIDATED', 'COMPLETED')
+                OR EXISTS (
+                    SELECT 1
+                    FROM document d
+                    WHERE d.tenant_id = t.id
+                      AND d.watermark_file_id IS NULL
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM guarantor g
+                    JOIN document d ON d.guarantor_id = g.id
+                    WHERE g.tenant_id = t.id
+                      AND d.watermark_file_id IS NULL
+                )
+              )
             """, nativeQuery = true)
     int countTenantsBlockingFullPdfGeneration(@Param("apartmentSharingId") long apartmentSharingId);
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
@@ -219,14 +219,16 @@ public interface TenantCommonRepository extends JpaRepository<Tenant, Long> {
     )
     List<Tenant> findAllDeclinedSinceXDaysAgo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
+    // The full dossier PDF can only be generated for COMPLETED or VALIDATED dossiers
+    // whose documents all have their watermarked file available
     @Query(value = """
             SELECT COUNT(t.id)
             FROM tenant t
             LEFT JOIN document d ON d.tenant_id = t.id OR d.guarantor_id = t.id
             WHERE t.apartment_sharing_id = :apartmentSharingId
-              AND ( t.status != 'VALIDATED' OR d.watermark_file_id IS NULL )
+              AND ( t.status NOT IN ('VALIDATED', 'COMPLETED') OR d.watermark_file_id IS NULL )
             """, nativeQuery = true)
-    int countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(@Param("apartmentSharingId") long apartmentSharingId);
+    int countTenantsBlockingFullPdfGeneration(@Param("apartmentSharingId") long apartmentSharingId);
 
     @Query("""
             SELECT DISTINCT t

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantLogRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantLogRepository.java
@@ -20,17 +20,6 @@ public interface TenantLogRepository extends JpaRepository<TenantLog, Long> {
             """, nativeQuery = true)
     long countProcessedDossiersFromToday();
 
-    // A dossier that has ever been validated (by an operator, automatically or by
-    // status recomputation) or denied can never become COMPLETED again
-    @Query(value = """
-            SELECT EXISTS (
-                SELECT 1 FROM tenant_log tl
-                WHERE tl.tenant_id = :tenantId
-                  AND tl.log_type IN ('ACCOUNT_VALIDATED', 'ACCOUNT_DENIED', 'ACCOUNT_AUTOMATICALLY_VALIDATED')
-            )
-            """, nativeQuery = true)
-    boolean hasBeenValidatedOrDenied(@Param("tenantId") Long tenantId);
-
     @Query(value = """
             WITH logs_window AS (
                 SELECT id, tenant_id, creation_date, log_type

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
@@ -8,6 +8,7 @@ import fr.dossierfacile.common.enums.LogType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.MailCommonService;
@@ -33,6 +34,7 @@ public class CompletedDossierServiceImpl implements CompletedDossierService {
     private final TenantLogCommonService tenantLogCommonService;
     private final TenantMapperForMail tenantMapperForMail;
     private final Optional<MailCommonService> mailCommonService;
+    private final ApartmentSharingCommonService apartmentSharingCommonService;
 
     @Override
     public TenantFileStatus toCompletedIfEligible(Tenant tenant, TenantFileStatus computedStatus) {
@@ -55,6 +57,9 @@ public class CompletedDossierServiceImpl implements CompletedDossierService {
         tenant.setLastUpdateDate(LocalDateTime.now(ZoneId.systemDefault()));
         tenantCommonRepository.save(tenant);
         tenantLogCommonService.saveTenantLog(new TenantLog(LogType.COMPLETED_SWITCHED_TO_PROCESS, tenant.getId()));
+        // The full PDF was rendered with the COMPLETED design: it must not
+        // survive the switch out of COMPLETED
+        apartmentSharingCommonService.resetDossierPdfGenerated(tenant.getApartmentSharing());
         if (userApi == null) {
             return;
         }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImpl.java
@@ -4,7 +4,6 @@ import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ApplicationType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
-import fr.dossierfacile.common.repository.TenantLogRepository;
 import fr.dossierfacile.common.repository.TenantUserApiRepository;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
@@ -18,13 +17,16 @@ import org.springframework.stereotype.Service;
 public class CompletedEligibilityServiceImpl implements CompletedEligibilityService {
 
     private final TenantUserApiRepository tenantUserApiRepository;
-    private final TenantLogRepository tenantLogRepository;
     private final FeatureFlagService featureFlagService;
 
     @Override
     public boolean isEligibleForOptIn(Tenant tenant) {
         TenantFileStatus status = tenant.getStatus();
-        if (status != TenantFileStatus.TO_PROCESS && status != TenantFileStatus.COMPLETED) {
+        // The question is available on any submitted dossier. On a VALIDATED or
+        // DECLINED dossier the choice has no immediate effect on the status: it
+        // applies to the next re-submission
+        if (status != TenantFileStatus.TO_PROCESS && status != TenantFileStatus.COMPLETED
+                && status != TenantFileStatus.VALIDATED && status != TenantFileStatus.DECLINED) {
             return false;
         }
         return checkEligibilityRules(tenant);
@@ -47,9 +49,6 @@ public class CompletedEligibilityServiceImpl implements CompletedEligibilityServ
         // Strict rule: any partner link (DFC or owner), even a dangling one, disables the opt-in
         // TODO(completed-optin): relax this rule once partners handle the COMPLETED status
         if (tenantUserApiRepository.existsByTenant(tenant)) {
-            return false;
-        }
-        if (tenantLogRepository.hasBeenValidatedOrDenied(tenant.getId())) {
             return false;
         }
         // The feature flag check comes last: its first evaluation persists a bucket

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/CompletedEligibilityService.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/CompletedEligibilityService.java
@@ -14,8 +14,10 @@ public interface CompletedEligibilityService {
 
     /**
      * Whether the opt-in choice is available to this tenant (drives the dashboard widget).
-     * Requires a submitted dossier (TO_PROCESS or COMPLETED), ALONE application, no partner
-     * link, never validated nor denied, and the feature flag enabled for this user.
+     * Requires a submitted dossier (TO_PROCESS, COMPLETED, VALIDATED or DECLINED), ALONE
+     * application, no partner link, and the feature flag enabled for this user.
+     * On a VALIDATED or DECLINED dossier the choice has no immediate effect on the status:
+     * it applies to the next re-submission.
      * Does NOT depend on {@code validationRequested}: the widget stays visible after an answer.
      */
     boolean isEligibleForOptIn(Tenant tenant);

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
@@ -1,6 +1,7 @@
 package fr.dossierfacile.common.service;
 
 import fr.dossierfacile.common.dto.mail.TenantDto;
+import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.entity.TenantLog;
 import fr.dossierfacile.common.entity.UserApi;
@@ -8,6 +9,7 @@ import fr.dossierfacile.common.enums.LogType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.MailCommonService;
 import fr.dossierfacile.common.service.interfaces.TenantLogCommonService;
@@ -21,6 +23,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 class CompletedDossierServiceImplTest {
@@ -30,10 +33,12 @@ class CompletedDossierServiceImplTest {
     private TenantLogCommonService tenantLogCommonService;
     private TenantMapperForMail tenantMapperForMail;
     private MailCommonService mailCommonService;
+    private ApartmentSharingCommonService apartmentSharingCommonService;
 
     private CompletedDossierServiceImpl service;
 
     private Tenant tenant;
+    private ApartmentSharing apartmentSharing;
 
     @BeforeEach
     void setUp() {
@@ -42,16 +47,19 @@ class CompletedDossierServiceImplTest {
         tenantLogCommonService = mock(TenantLogCommonService.class);
         tenantMapperForMail = mock(TenantMapperForMail.class);
         mailCommonService = mock(MailCommonService.class);
+        apartmentSharingCommonService = mock(ApartmentSharingCommonService.class);
 
         service = new CompletedDossierServiceImpl(
                 completedEligibilityService,
                 tenantCommonRepository,
                 tenantLogCommonService,
                 tenantMapperForMail,
-                Optional.of(mailCommonService)
+                Optional.of(mailCommonService),
+                apartmentSharingCommonService
         );
 
-        tenant = Tenant.builder().id(100L).build();
+        apartmentSharing = ApartmentSharing.builder().id(300L).build();
+        tenant = Tenant.builder().id(100L).apartmentSharing(apartmentSharing).build();
     }
 
     @Nested
@@ -108,6 +116,8 @@ class CompletedDossierServiceImplTest {
                 verify(tenantCommonRepository).save(tenant);
                 verify(tenantLogCommonService).saveTenantLog(argThat(log ->
                         log.getLogType() == LogType.COMPLETED_SWITCHED_TO_PROCESS && log.getTenantId().equals(tenant.getId())));
+                // The full PDF rendered with the COMPLETED design is dropped
+                verify(apartmentSharingCommonService).resetDossierPdfGenerated(apartmentSharing);
 
                 // And - the mail mentioning the partner is sent after commit
                 verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
@@ -130,6 +140,7 @@ class CompletedDossierServiceImplTest {
             assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.TO_PROCESS);
             verify(tenantCommonRepository).save(tenant);
             verify(tenantLogCommonService).saveTenantLog(any(TenantLog.class));
+            verify(apartmentSharingCommonService).resetDossierPdfGenerated(apartmentSharing);
             verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
         }
 
@@ -142,6 +153,7 @@ class CompletedDossierServiceImplTest {
             assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.VALIDATED);
             verify(tenantCommonRepository, never()).save(any(Tenant.class));
             verify(tenantLogCommonService, never()).saveTenantLog(any(TenantLog.class));
+            verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
             verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
         }
     }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImplTest.java
@@ -4,7 +4,6 @@ import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ApplicationType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
-import fr.dossierfacile.common.repository.TenantLogRepository;
 import fr.dossierfacile.common.repository.TenantUserApiRepository;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
@@ -25,8 +24,6 @@ class CompletedEligibilityServiceImplTest {
     @Mock
     private TenantUserApiRepository tenantUserApiRepository;
     @Mock
-    private TenantLogRepository tenantLogRepository;
-    @Mock
     private FeatureFlagService featureFlagService;
 
     @InjectMocks
@@ -46,7 +43,6 @@ class CompletedEligibilityServiceImplTest {
 
     private void mockFullEligibility(Tenant tenant, boolean flagEnabled) {
         when(tenantUserApiRepository.existsByTenant(tenant)).thenReturn(false);
-        when(tenantLogRepository.hasBeenValidatedOrDenied(tenant.getId())).thenReturn(false);
         when(featureFlagService.isFeatureEnabledForUser(tenant.getId(), CompletedEligibilityService.COMPLETED_OPTIN_FEATURE_FLAG))
                 .thenReturn(flagEnabled);
     }
@@ -71,14 +67,26 @@ class CompletedEligibilityServiceImplTest {
         }
 
         @Test
+        void should_be_eligible_when_dossier_has_already_been_reviewed() {
+            // On a VALIDATED or DECLINED dossier the choice applies to the next re-submission
+            for (TenantFileStatus status : new TenantFileStatus[]{
+                    TenantFileStatus.VALIDATED, TenantFileStatus.DECLINED}) {
+                Tenant tenant = buildTenant(status, ApplicationType.ALONE);
+                mockFullEligibility(tenant, true);
+
+                assertThat(completedEligibilityService.isEligibleForOptIn(tenant)).isTrue();
+            }
+        }
+
+        @Test
         void should_not_be_eligible_when_dossier_is_not_submitted() {
             for (TenantFileStatus status : new TenantFileStatus[]{
-                    TenantFileStatus.INCOMPLETE, TenantFileStatus.VALIDATED, TenantFileStatus.DECLINED, TenantFileStatus.ARCHIVED}) {
+                    TenantFileStatus.INCOMPLETE, TenantFileStatus.ARCHIVED}) {
                 Tenant tenant = buildTenant(status, ApplicationType.ALONE);
 
                 assertThat(completedEligibilityService.isEligibleForOptIn(tenant)).isFalse();
             }
-            verifyNoInteractions(tenantUserApiRepository, tenantLogRepository, featureFlagService);
+            verifyNoInteractions(tenantUserApiRepository, featureFlagService);
         }
 
         @Test
@@ -88,7 +96,7 @@ class CompletedEligibilityServiceImplTest {
 
                 assertThat(completedEligibilityService.isEligibleForOptIn(tenant)).isFalse();
             }
-            verifyNoInteractions(tenantUserApiRepository, tenantLogRepository, featureFlagService);
+            verifyNoInteractions(tenantUserApiRepository, featureFlagService);
         }
 
         @Test
@@ -98,16 +106,6 @@ class CompletedEligibilityServiceImplTest {
 
             assertThat(completedEligibilityService.isEligibleForOptIn(tenant)).isFalse();
             // The flag must not be checked (nor assign a bucket) for non-candidates
-            verifyNoInteractions(tenantLogRepository, featureFlagService);
-        }
-
-        @Test
-        void should_not_be_eligible_when_dossier_has_ever_been_validated_or_denied() {
-            Tenant tenant = buildTenant(TenantFileStatus.TO_PROCESS, ApplicationType.ALONE);
-            when(tenantUserApiRepository.existsByTenant(tenant)).thenReturn(false);
-            when(tenantLogRepository.hasBeenValidatedOrDenied(tenant.getId())).thenReturn(true);
-
-            assertThat(completedEligibilityService.isEligibleForOptIn(tenant)).isFalse();
             verifyNoInteractions(featureFlagService);
         }
 
@@ -129,7 +127,7 @@ class CompletedEligibilityServiceImplTest {
             tenant.setValidationRequested(true);
 
             assertThat(completedEligibilityService.canBeCompleted(tenant)).isFalse();
-            verifyNoInteractions(tenantUserApiRepository, tenantLogRepository, featureFlagService);
+            verifyNoInteractions(tenantUserApiRepository, featureFlagService);
         }
 
         @Test

--- a/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/ApartmentSharingPdfDossierFileGenerationServiceImpl.java
+++ b/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/ApartmentSharingPdfDossierFileGenerationServiceImpl.java
@@ -35,6 +35,15 @@ public class ApartmentSharingPdfDossierFileGenerationServiceImpl implements Apar
 
         ApartmentSharing apartmentSharing = optionalApartmentSharing.get();
 
+        // The generation was invalidated while rendering (document modified, or dossier
+        // switched out of COMPLETED/VALIDATED): discard the freshly generated file
+        if (apartmentSharing.getDossierPdfDocumentStatus() != FileStatus.IN_PROGRESS) {
+            log.warn("Dossier PDF of ApartmentSharing {} is no longer IN_PROGRESS (status: {}), discarding the generated file",
+                    id, apartmentSharing.getDossierPdfDocumentStatus());
+            fileStorageService.delete(file);
+            return;
+        }
+
         // Mark previous pdfDossierFile as TO_DELETE before replacing
         StorageFile previousPdfDossierFile = apartmentSharing.getPdfDossierFile();
         if (previousPdfDossierFile != null) {

--- a/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplate.java
+++ b/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplate.java
@@ -15,6 +15,7 @@ import fr.dossierfacile.common.entity.Guarantor;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.ApplicationType;
 import fr.dossierfacile.common.enums.DocumentCategory;
+import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.enums.TypeGuarantor;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
@@ -174,6 +175,10 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
     private static final float LEADING_FOR_CLARIFICATION_TEXT = B_HEIGHT_TEMPLATE / 421 * 8.23f;
     private static final float LEFT_MARGIN_FOR_CLARIFICATION_TEXT = FONT_SIZE_FOR_PAGINATION;
 
+    // Bottom of the band holding the RF and DossierFacile logos at the top of the
+    // attachments template (just above the text headers drawn by code)
+    private static final float Y_BOTTOM_OF_HEADER_LOGOS_AREA = B_HEIGHT_TEMPLATE / 421 * 365f;
+
     private static final float FONT_SIZE_FOR_STATIC_TEXT_IN_FIRST_TEMPLATE = B_HEIGHT_TEMPLATE / 421 * 8.37f;
 
     private static final float FONT_SIZE_FOR_FIRST_NAMES_OF_TENANTS_IN_HEADER_OF_INDEXPAGES = B_HEIGHT_TEMPLATE / 421 * 10f;
@@ -267,7 +272,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         }
     }
 
-    private ByteArrayOutputStream addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(List<Tenant> tenantList, String headerSentence, String bodyText) {
+    private ByteArrayOutputStream addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(List<Tenant> tenantList, String headerSentence, String bodyText, boolean hideHeaderLogos) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (PDDocument doc = ATTACHMENTS_AND_CLARIFICATIONS.load()) {
 
@@ -280,6 +285,17 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
             //endregion
 
             PDPage pageTemplate = doc.getPage(0);
+
+            if (hideHeaderLogos) {
+                // A COMPLETED (non verified) dossier must not carry the République
+                // Française and DossierFacile logos: cover the top band of the template
+                // before drawing the text headers
+                try (PDPageContentStream cover = new PDPageContentStream(doc, pageTemplate, PDPageContentStream.AppendMode.APPEND, true)) {
+                    cover.setNonStrokingColor(Color.WHITE);
+                    cover.addRect(0, Y_BOTTOM_OF_HEADER_LOGOS_AREA, A_WIDTH_TEMPLATE, B_HEIGHT_TEMPLATE - Y_BOTTOM_OF_HEADER_LOGOS_AREA);
+                    cover.fill();
+                }
+            }
 
             //region Text Header 1
             PDPageContentStream contentStream1 = new PDPageContentStream(doc, pageTemplate, PDPageContentStream.AppendMode.APPEND, true);
@@ -552,9 +568,9 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         }
     }
 
-    private void addDocument(PDFMergerUtility ut, InputStream pdfDocument, List<Integer> indexPagesForDocuments, boolean newCategoryDocument, List<Tenant> tenantList, String headerSentence) {
+    private void addDocument(PDFMergerUtility ut, InputStream pdfDocument, List<Integer> indexPagesForDocuments, boolean newCategoryDocument, List<Tenant> tenantList, String headerSentence, boolean hideHeaderLogos) {
 
-        ByteArrayOutputStream templateWithTextsHeader = addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(tenantList, headerSentence, null);
+        ByteArrayOutputStream templateWithTextsHeader = addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(tenantList, headerSentence, null, hideHeaderLogos);
 
         try (PDDocument innerDocument = Loader.loadPDF(pdfDocument.readAllBytes())) {
 
@@ -573,7 +589,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
 
     }
 
-    private void addDocumentOfClarification(PDFMergerUtility ut, List<Tenant> tenantList, Tenant mainTenant, List<Integer> indexPagesForDocuments, PDOutlineItem pdOutlineItem) {
+    private void addDocumentOfClarification(PDFMergerUtility ut, List<Tenant> tenantList, Tenant mainTenant, List<Integer> indexPagesForDocuments, PDOutlineItem pdOutlineItem, boolean hideHeaderLogos) {
         if (StringUtils.isNotBlank(mainTenant.getClarification())) {
             //region Adding bookmark
             PDPageFitWidthDestination destination = new PDPageFitWidthDestination();
@@ -587,7 +603,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
             pdOutlineItem.addLast(pdO);
             //endregion
 
-            ByteArrayOutputStream outputStream = addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(tenantList, LE_MOT_DU_LOCATAIRE, mainTenant.getClarification());
+            ByteArrayOutputStream outputStream = addTextHeaderAndTextBodyToTheCopyOfAttachmentsAndClarificationTemplate(tenantList, LE_MOT_DU_LOCATAIRE, mainTenant.getClarification(), hideHeaderLogos);
             ut.addSource(new RandomAccessReadBuffer(outputStream.toByteArray()));
             indexPagesForDocuments.add(indexPagesForDocuments.get(indexPagesForDocuments.size() - 1) + 1);
         } else {
@@ -798,7 +814,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         contentStream2.close();
     }
 
-    private void addFilesOfDocumentsToDossierPDF(PDFMergerUtility ut, List<Tenant> tenantList, List<Integer> indexPagesForDocuments, PDOutlineItem pdOutlineItem) {
+    private void addFilesOfDocumentsToDossierPDF(PDFMergerUtility ut, List<Tenant> tenantList, List<Integer> indexPagesForDocuments, PDOutlineItem pdOutlineItem, boolean hideHeaderLogos) {
         for (Tenant tenant1 : tenantList) {
             boolean firstDocumentTenant = true;
             //region Adding bookmark
@@ -841,7 +857,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
 
                 //We get here the second sentence located in the header of attachment pages for the current tenant
                 String sentence = getSentenceForTenantFromDocumentCategory(tenant1, currentCategory, count);
-                addDocument(ut, documentInputStream, indexPagesForDocuments, firstDocumentSubject || previousCategory != currentCategory, tenantList, sentence);
+                addDocument(ut, documentInputStream, indexPagesForDocuments, firstDocumentSubject || previousCategory != currentCategory, tenantList, sentence, hideHeaderLogos);
                 firstDocumentSubject = false;
                 previousCategory = currentCategory;
             }
@@ -908,7 +924,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
 
                     //We get here the second sentence located in the header of attachment pages for the current guarantor
                     String sentence = getSentenceForGuarantorFromDocumentCategory(counterOfGuarantor, guarantor1.getTypeGuarantor(), currentCategory, tenant1.getFirstName(), counter);
-                    addDocument(ut, documentInputStream, indexPagesForDocuments, firstDocumentSubject || previousCategory != currentCategory, tenantList, sentence);
+                    addDocument(ut, documentInputStream, indexPagesForDocuments, firstDocumentSubject || previousCategory != currentCategory, tenantList, sentence, hideHeaderLogos);
                     firstDocumentSubject = false;
                     previousCategory = currentCategory;
 
@@ -1221,8 +1237,89 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         return yLocation;
     }
 
-    private void checkingAllTenantsInTheApartmentAreValidatedAndAllDocumentsAreNotNull(long apartmentSharingId, Long id) {
-        int numberOfTenants = tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(apartmentSharingId);
+    // Fills the index pages (added by createFirstsPages) with the summary boxes and
+    // the clickable per-tenant document indexes. Not called for a COMPLETED dossier,
+    // which has no index pages.
+    private void fillIndexPages(PDDocument doc, ApartmentSharing apartmentSharing, List<Tenant> tenantList, List<Integer> indexPagesForDocuments) throws IOException {
+        PDType0Font fontSpectralExtraBold = Fonts.SPECTRAL_EXTRA_BOLD.load(doc);
+        PDType0Font fontMarianneRegular = Fonts.MARIANNE_REGULAR.load(doc);
+        PDType0Font fontMarianneBold = Fonts.MARIANNE_BOLD.load(doc);
+
+        int numberOfTenants = tenantList.size();
+
+        /* Initialized in 2, because this is the position in the array (indexPagesForDocuments)
+        where it is located the number of the page located before the beginning of attachment pages.
+        - (position 1) ------> indexPagesForDocuments[0] = Number of index pages. For 1 or 2 tenants then 1 page, for 3 or 4 tenants then 2 pages, ...
+        - (position 2) ------> indexPagesForDocuments[1] = Page number where the clarification page is.
+        -              ------> indexPagesForDocuments[1] + 1 = page number of the first attachment page.
+        - (last position) ---> indexPagesForDocuments[indexPagesForDocuments.size() - 1] = doc.getNumberOfPages() */
+        AtomicInteger iteratorInIndexPagesForDocuments = new AtomicInteger(2);
+
+        int indexTenant = 0;
+        int totalPages = doc.getNumberOfPages();
+        for (int indexPage = 0; indexPage < totalPages && indexTenant < numberOfTenants; indexPage++) {
+
+            addFirstNamesOfTenantsInTheHeaderOfCurrentIndexPage(indexPage, doc, tenantList, fontSpectralExtraBold);
+
+            Tenant leftTenantInPage = tenantList.get(indexTenant);
+            Tenant rightTenantInPage = (indexTenant + 1) < numberOfTenants ? tenantList.get(indexTenant + 1) : null;
+
+            float yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream;
+
+            //The content area in the first page (indexPage == 0)
+            // is different in comparision with the one available in the other pages of indexes
+            if (indexPage == 0) {
+                //region Static Text (Le dossier en un clin d’oeil)
+                addStaticTextInFirstTemplateOfIndexes(indexPage, doc, fontSpectralExtraBold);
+                //endregion
+                //region Text Box (Type de dossier)
+                addContentInFirstRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, apartmentSharing.getApplicationType());
+                //endregion
+                //region Text Box (Revenus mensuels nets cumulés)
+                addContentInSecondRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, fontMarianneBold, apartmentSharing.totalSalary() + " €");
+                //endregion
+                //region Text Box (Leur garant)
+                addContentInThirdRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, fontMarianneBold, tenantList);
+                //endregion
+
+                //region ContentStreams locations on the y-axis in first page of indexes
+                yLocationFirstContentStream = Y_LOCATION_OF_TITLE_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
+                yLocationSecondContentStream = Y_LOCATION_OF_NAME_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
+                yLocationTenantEmailContentStream = Y_LOCATION_OF_EMAIL_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
+                yLocationThirdContentStream = Y_LOCATION_OF_INDEX_PAGES_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
+                //endregion
+            } else {
+                //region ContentStreams locations on the y-axis in the other pages of indexes
+                yLocationFirstContentStream = Y_LOCATION_OF_TITLE_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
+                yLocationSecondContentStream = Y_LOCATION_OF_NAME_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
+                yLocationTenantEmailContentStream = Y_LOCATION_OF_EMAIL_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
+                yLocationThirdContentStream = Y_LOCATION_OF_INDEX_PAGES_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
+                //endregion
+            }
+
+            //region Details of left Tenant in current page
+            float lastYLocationLeftSide = addIndexesOfDocumentsOfTenantInCurrentPage(leftTenantInPage, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_LEFT_TENANT, yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream, X_LOCATION_OF_END_OF_LEFT_RECTANGULE_IN_INDEXPAGES);
+            List<Guarantor> guarantorsLeftTenant = leftTenantInPage.getGuarantors().stream().sorted(Comparator.comparing(Guarantor::getTypeGuarantor)).collect(Collectors.toList());
+            for (Guarantor guarantor : guarantorsLeftTenant) {
+                lastYLocationLeftSide = addIndexesOfDocumentsOfGuarantorInCurrentPage(guarantor, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_LEFT_TENANT, lastYLocationLeftSide, X_LOCATION_OF_END_OF_LEFT_RECTANGULE_IN_INDEXPAGES);
+            }
+            //endregion
+            //region Details of right Tenant in current page
+            if (rightTenantInPage != null) {
+                float lastYLocationRightSide = addIndexesOfDocumentsOfTenantInCurrentPage(rightTenantInPage, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_RIGHT_TENANT, yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream, X_LOCATION_OF_END_OF_RIGHT_RECTANGULE_IN_INDEXPAGES);
+                List<Guarantor> guarantorsRightTenant = rightTenantInPage.getGuarantors().stream().sorted(Comparator.comparing(Guarantor::getTypeGuarantor)).collect(Collectors.toList());
+                for (Guarantor guarantor : guarantorsRightTenant) {
+                    lastYLocationRightSide = addIndexesOfDocumentsOfGuarantorInCurrentPage(guarantor, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_RIGHT_TENANT, lastYLocationRightSide, X_LOCATION_OF_END_OF_RIGHT_RECTANGULE_IN_INDEXPAGES);
+                }
+            }
+            //endregion
+
+            indexTenant += 2;
+        }
+    }
+
+    private void checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(long apartmentSharingId, Long id) {
+        int numberOfTenants = tenantRepository.countTenantsBlockingFullPdfGeneration(apartmentSharingId);
         if (numberOfTenants > 0) {
             throw new ApartmentSharingUnexpectedException(id);
         }
@@ -1231,7 +1328,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
     @Override
     public InputStream render(ApartmentSharing apartmentSharing) throws IOException {
 
-        checkingAllTenantsInTheApartmentAreValidatedAndAllDocumentsAreNotNull(apartmentSharing.getId(), apartmentSharing.getId());
+        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), apartmentSharing.getId());
 
         PDFMergerUtility ut = new PDFMergerUtility();
         List<Tenant> tenantList = apartmentSharing.getTenants().stream().sorted(Comparator.comparing(Tenant::getTenantType)).collect(Collectors.toList());
@@ -1252,17 +1349,27 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         pdDocumentOutline.addLast(pdOutlineItem);
         //endregion
 
-        createFirstsPages(ut, numberOfTenants, indexPagesForDocuments, pdOutlineItem);
+        // A COMPLETED (non verified) dossier renders without the index pages and
+        // without the RF/DossierFacile logos in the header of the pages (clarification
+        // page included). A VALIDATED dossier keeps the historical rendering.
+        boolean completedDossier = apartmentSharing.getStatus() == TenantFileStatus.COMPLETED;
+
+        if (completedDossier) {
+            // No index pages: the content starts at page 0
+            indexPagesForDocuments.add(0);
+        } else {
+            createFirstsPages(ut, numberOfTenants, indexPagesForDocuments, pdOutlineItem);
+        }
 
         Tenant mainTenant = tenantList.stream()
                 .filter(t -> t.getTenantType() == TenantType.CREATE)
                 .findFirst()
                 .orElseThrow(() -> new TenantNotFoundException(TenantType.CREATE));
 
-        addDocumentOfClarification(ut, tenantList, mainTenant, indexPagesForDocuments, pdOutlineItem);
+        addDocumentOfClarification(ut, tenantList, mainTenant, indexPagesForDocuments, pdOutlineItem, completedDossier);
 
         //region Add files of documents to Dossier PDF
-        addFilesOfDocumentsToDossierPDF(ut, tenantList, indexPagesForDocuments, pdOutlineItem);
+        addFilesOfDocumentsToDossierPDF(ut, tenantList, indexPagesForDocuments, pdOutlineItem, completedDossier);
         //endregion
 
         ByteArrayOutputStream merge = new ByteArrayOutputStream();
@@ -1284,81 +1391,9 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
 
             addPaginate(doc);
 
-            //region Adding content to First pages
-            PDType0Font fontSpectralExtraBold = Fonts.SPECTRAL_EXTRA_BOLD.load(doc);
-            PDType0Font fontMarianneRegular = Fonts.MARIANNE_REGULAR.load(doc);
-            PDType0Font fontMarianneBold = Fonts.MARIANNE_BOLD.load(doc);
-
-            /* Initialized in 2, because this is the position in the array (indexPagesForDocuments)
-            where it is located the number of the page located before the beginning of attachment pages.
-            - (position 1) ------> indexPagesForDocuments[0] = Number of index pages. For 1 or 2 tenants then 1 page, for 3 or 4 tenants then 2 pages, ...
-            - (position 2) ------> indexPagesForDocuments[1] = Page number where the clarification page is.
-            -              ------> indexPagesForDocuments[1] + 1 = page number of the first attachment page.
-            - (last position) ---> indexPagesForDocuments[indexPagesForDocuments.size() - 1] = doc.getNumberOfPages() */
-            AtomicInteger iteratorInIndexPagesForDocuments = new AtomicInteger(2);
-
-            int indexTenant = 0;
-            int totalPages = doc.getNumberOfPages();
-            for (int indexPage = 0; indexPage < totalPages && indexTenant < numberOfTenants; indexPage++) {
-
-                addFirstNamesOfTenantsInTheHeaderOfCurrentIndexPage(indexPage, doc, tenantList, fontSpectralExtraBold);
-
-                Tenant leftTenantInPage = tenantList.get(indexTenant);
-                Tenant rightTenantInPage = (indexTenant + 1) < numberOfTenants ? tenantList.get(indexTenant + 1) : null;
-
-                float yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream;
-
-                //The content area in the first page (indexPage == 0)
-                // is different in comparision with the one available in the other pages of indexes
-                if (indexPage == 0) {
-                    //region Static Text (Le dossier en un clin d’oeil)
-                    addStaticTextInFirstTemplateOfIndexes(indexPage, doc, fontSpectralExtraBold);
-                    //endregion
-                    //region Text Box (Type de dossier)
-                    addContentInFirstRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, apartmentSharing.getApplicationType());
-                    //endregion
-                    //region Text Box (Revenus mensuels nets cumulés)
-                    addContentInSecondRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, fontMarianneBold, apartmentSharing.totalSalary() + " €");
-                    //endregion
-                    //region Text Box (Leur garant)
-                    addContentInThirdRectanguleInFirstTemplateOfIndexes(indexPage, doc, fontMarianneRegular, fontMarianneBold, tenantList);
-                    //endregion
-
-                    //region ContentStreams locations on the y-axis in first page of indexes
-                    yLocationFirstContentStream = Y_LOCATION_OF_TITLE_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
-                    yLocationSecondContentStream = Y_LOCATION_OF_NAME_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
-                    yLocationTenantEmailContentStream = Y_LOCATION_OF_EMAIL_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
-                    yLocationThirdContentStream = Y_LOCATION_OF_INDEX_PAGES_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_FIRST_INDEXPAGE;
-                    //endregion
-                } else {
-                    //region ContentStreams locations on the y-axis in the other pages of indexes
-                    yLocationFirstContentStream = Y_LOCATION_OF_TITLE_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
-                    yLocationSecondContentStream = Y_LOCATION_OF_NAME_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
-                    yLocationTenantEmailContentStream = Y_LOCATION_OF_EMAIL_OF_TENANT_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
-                    yLocationThirdContentStream = Y_LOCATION_OF_INDEX_PAGES_IN_GROUP_OF_DOCUMENT_INDEXES_FOR_TENANTS_IN_SECOND_INDEXPAGE;
-                    //endregion
-                }
-
-                //region Details of left Tenant in current page
-                float lastYLocationLeftSide = addIndexesOfDocumentsOfTenantInCurrentPage(leftTenantInPage, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_LEFT_TENANT, yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream, X_LOCATION_OF_END_OF_LEFT_RECTANGULE_IN_INDEXPAGES);
-                List<Guarantor> guarantorsLeftTenant = leftTenantInPage.getGuarantors().stream().sorted(Comparator.comparing(Guarantor::getTypeGuarantor)).collect(Collectors.toList());
-                for (Guarantor guarantor : guarantorsLeftTenant) {
-                    lastYLocationLeftSide = addIndexesOfDocumentsOfGuarantorInCurrentPage(guarantor, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_LEFT_TENANT, lastYLocationLeftSide, X_LOCATION_OF_END_OF_LEFT_RECTANGULE_IN_INDEXPAGES);
-                }
-                //endregion
-                //region Details of right Tenant in current page
-                if (rightTenantInPage != null) {
-                    float lastYLocationRightSide = addIndexesOfDocumentsOfTenantInCurrentPage(rightTenantInPage, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_RIGHT_TENANT, yLocationFirstContentStream, yLocationSecondContentStream, yLocationTenantEmailContentStream, yLocationThirdContentStream, X_LOCATION_OF_END_OF_RIGHT_RECTANGULE_IN_INDEXPAGES);
-                    List<Guarantor> guarantorsRightTenant = rightTenantInPage.getGuarantors().stream().sorted(Comparator.comparing(Guarantor::getTypeGuarantor)).collect(Collectors.toList());
-                    for (Guarantor guarantor : guarantorsRightTenant) {
-                        lastYLocationRightSide = addIndexesOfDocumentsOfGuarantorInCurrentPage(guarantor, indexPage, indexPagesForDocuments, iteratorInIndexPagesForDocuments, doc, fontSpectralExtraBold, fontMarianneRegular, LEFT_MARGIN_FOR_RIGHT_TENANT, lastYLocationRightSide, X_LOCATION_OF_END_OF_RIGHT_RECTANGULE_IN_INDEXPAGES);
-                    }
-                }
-                //endregion
-
-                indexTenant += 2;
+            if (!completedDossier) {
+                fillIndexPages(doc, apartmentSharing, tenantList, indexPagesForDocuments);
             }
-            //endregion
             doc.save(result);
             log.info("Generation completed");
         } catch (IOException e) {

--- a/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/ApartmentSharingPdfDossierFileGenerationServiceImplTest.java
+++ b/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/ApartmentSharingPdfDossierFileGenerationServiceImplTest.java
@@ -1,0 +1,80 @@
+package fr.dossierfacile.api.pdfgenerator.service;
+
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.StorageFile;
+import fr.dossierfacile.common.enums.FileStatus;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.FileStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ApartmentSharingPdfDossierFileGenerationServiceImplTest {
+
+    private ApartmentSharingCommonService apartmentSharingCommonService;
+    private FileStorageService fileStorageService;
+
+    private ApartmentSharingPdfDossierFileGenerationServiceImpl service;
+
+    private StorageFile generatedFile;
+
+    @BeforeEach
+    void setUp() {
+        apartmentSharingCommonService = mock(ApartmentSharingCommonService.class);
+        fileStorageService = mock(FileStorageService.class);
+        service = new ApartmentSharingPdfDossierFileGenerationServiceImpl(apartmentSharingCommonService, fileStorageService);
+        generatedFile = StorageFile.builder().id(42L).build();
+    }
+
+    @Test
+    void complete_attachesFile_whenGenerationIsStillInProgress() {
+        ApartmentSharing apartmentSharing = ApartmentSharing.builder()
+                .id(1L)
+                .dossierPdfDocumentStatus(FileStatus.IN_PROGRESS)
+                .build();
+        when(apartmentSharingCommonService.findById(1L)).thenReturn(Optional.of(apartmentSharing));
+
+        service.complete(1L, generatedFile);
+
+        assertThat(apartmentSharing.getPdfDossierFile()).isEqualTo(generatedFile);
+        assertThat(apartmentSharing.getDossierPdfDocumentStatus()).isEqualTo(FileStatus.COMPLETED);
+        verify(apartmentSharingCommonService).save(apartmentSharing);
+        verify(fileStorageService, never()).delete(any(StorageFile.class));
+    }
+
+    @Test
+    void complete_discardsFile_whenGenerationWasInvalidatedDuringRendering() {
+        // The dossier changed or left the COMPLETED/VALIDATED state while the PDF
+        // was being rendered: resetDossierPdfGenerated() set the status to DELETED
+        ApartmentSharing apartmentSharing = ApartmentSharing.builder()
+                .id(1L)
+                .dossierPdfDocumentStatus(FileStatus.DELETED)
+                .build();
+        when(apartmentSharingCommonService.findById(1L)).thenReturn(Optional.of(apartmentSharing));
+
+        service.complete(1L, generatedFile);
+
+        assertThat(apartmentSharing.getPdfDossierFile()).isNull();
+        assertThat(apartmentSharing.getDossierPdfDocumentStatus()).isEqualTo(FileStatus.DELETED);
+        verify(apartmentSharingCommonService, never()).save(any(ApartmentSharing.class));
+        verify(fileStorageService).delete(generatedFile);
+    }
+
+    @Test
+    void complete_discardsFile_whenApartmentSharingWasDeleted() {
+        when(apartmentSharingCommonService.findById(1L)).thenReturn(Optional.empty());
+
+        service.complete(1L, generatedFile);
+
+        verify(apartmentSharingCommonService, never()).save(any(ApartmentSharing.class));
+        verify(fileStorageService).delete(generatedFile);
+    }
+}

--- a/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/PdfGeneratorServiceImplTest.java
+++ b/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/PdfGeneratorServiceImplTest.java
@@ -62,7 +62,7 @@ class PdfGeneratorServiceImplTest {
         Mockito.when(apartmentSharingCommonService.findById(1L)).thenReturn(Optional.of(apartmentSharing));
         Mockito.when(apartmentSharingCommonService.save(ArgumentMatchers.any())).thenAnswer(i -> i.getArguments()[0]);
 
-        Mockito.when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(1L)).thenReturn(0);
+        Mockito.when(tenantRepository.countTenantsBlockingFullPdfGeneration(1L)).thenReturn(0);
 
         pdfGeneratorService.generateFullDossierPdf(1L);
 

--- a/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplateTest.java
+++ b/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplateTest.java
@@ -3,6 +3,7 @@ package fr.dossierfacile.api.pdfgenerator.service.templates;
 import fr.dossierfacile.api.pdfgenerator.service.DownloadServiceImpl;
 import fr.dossierfacile.api.pdfgenerator.util.parameterresolvers.ApartmentSharingResolver;
 import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.service.interfaces.MailCommonService;
 import fr.dossierfacile.logging.job.LogAggregator;
@@ -40,13 +41,27 @@ public class ApartmentSharingPdfDocumentTemplateTest {
 
     @BeforeEach
     void init_mocks() {
-        Mockito.when(tenantRepository.countTenantsInTheApartmentNotValidatedOrWithSomeNullDocument(anyLong())).thenReturn(0);
+        Mockito.when(tenantRepository.countTenantsBlockingFullPdfGeneration(anyLong())).thenReturn(0);
         Mockito.when(downloadService.getDocumentInputStream(any())).then(answer -> ApartmentSharingPdfDocumentTemplateTest.class.getResourceAsStream("/CNI.pdf"));
     }
 
     @Test
     void should_generate_pdf(ApartmentSharing apartmentSharing) throws IOException {
         File resultFile = new File("target/fullPdfGeneration.pdf");
+
+        try (FileOutputStream w = new FileOutputStream(resultFile); InputStream is = pdfService.render(apartmentSharing)) {
+            byte[] result = is.readAllBytes();
+            w.write(result);
+            Assertions.assertThat(result).isNotEmpty();
+        }
+    }
+
+    // A COMPLETED dossier renders with the dedicated first-page template
+    // (visual check: target/fullPdfGenerationCompleted.pdf)
+    @Test
+    void should_generate_pdf_for_completed_dossier(ApartmentSharing apartmentSharing) throws IOException {
+        apartmentSharing.getTenants().forEach(tenant -> tenant.setStatus(TenantFileStatus.COMPLETED));
+        File resultFile = new File("target/fullPdfGenerationCompleted.pdf");
 
         try (FileOutputStream w = new FileOutputStream(resultFile); InputStream is = pdfService.render(apartmentSharing)) {
             byte[] result = is.readAllBytes();


### PR DESCRIPTION
## Contexte

Suite du MVP opt-in (#1293) : le statut `COMPLETED` (dossier complet soumis, non vérifié par un opérateur) était limité au partage ZIP. Cette PR ouvre le partage par lien et par mail aux dossiers `COMPLETED`, avec un full PDF au rendu différencié, et assouplit l'éligibilité au statut pour permettre l'opt-out des dossiers déjà examinés. Les verrous d'invisibilité partenaires sont inchangés (un dossier lié à un partenaire ne peut jamais être `COMPLETED` ; toute liaison le rebascule en `TO_PROCESS`).

## Changements

### 1. Partage lien/mail ouvert aux dossiers COMPLETED
- `TenantFileStatus.isCompletedOrValidated()` : nouveau prédicat porté par l'enum.
- `createSharingLink`, `sendFileByMail` et `PUT /api/application/links/default` acceptent `VALIDATED` **ou** `COMPLETED` (`requireCompletedOrValidatedDossier`, 409 sinon).
- Suppression du garde `requireNotCompletedDossier` sur l'activation, le renvoi et la réactivation globale des liens.
- Le mail de partage reste sur le template Brevo 89 pour les deux statuts (wording à adapter côté Brevo).

### 2. Full PDF
- Précondition de génération élargie : tous les tenants `VALIDATED` **ou** `COMPLETED` + watermarks présents (`countTenantsBlockingFullPdfGeneration`, 417 sinon).
- **Rendu `COMPLETED` neutre** : pas de page de garde ni de pages d'index ; la page « Le mot du locataire » est conservée en ouverture (si renseignée) ; les logos République Française / DossierFacile sont masqués de l'en-tête de toutes les pages (aplat dessiné avant les textes d'en-tête, qui restent).
- **Rendu `VALIDATED` strictement inchangé** (template historique).
- Refactor associé : extraction de `fillIndexPages(...)` dans `ApartmentSharingPdfDocumentTemplate`.

### 3. Cycle de vie du PDF
- Toute sortie de `COMPLETED` (opt-in « oui », liaison partenaire, rollback BO) invalide le PDF (`resetDossierPdfGenerated`) : un PDF au rendu « non vérifié » ne survit jamais au changement de statut.
- Garde anti-race dans `complete()` (pdf-generator) : un fichier généré pendant une invalidation concurrente est jeté au lieu d'être attaché (corrige aussi une race préexistante sur modification de document pendant génération).

### 4. Opt-out des dossiers déjà examinés
- La règle d'éligibilité « jamais validé ni refusé » est supprimée (requête `hasBeenValidatedOrDenied` retirée). Seul le **choix persistant** décide du statut à la re-soumission : `validation_requested = true` → `TO_PROCESS` ; `false`/`null` → `COMPLETED` (défaut = opt-out).
- `isEligibleForOptIn` accepte aussi `VALIDATED` et `DECLINED` : le choix y est enregistré sans effet immédiat (le recalcul de statut est un no-op) et s'applique à la re-soumission. `optInEligible` est donc exposé pour ces dossiers ; le front actuel n'affiche l'encart que pour `COMPLETED`/`TO_PROCESS` (UI dédiée à venir).

### 5. Documentation
`docs/completed-optin.md` mis à jour : §3 (éligibilité), §5.4/§6/§7 (liens & PDF, trois verrous), scénarios §13.

## Tests manuels (QA)

Préparation : préprod, flag `tenant_completed_optin` actif à 100 %, compte créé après activation, dossier **ALONE** complet signé → statut `COMPLETED`. ⚠️ Les parcours UI complets nécessitent la PR frontend ; sans elle, tester les verrous via appels API directs.

**Partage d'un dossier COMPLETED**
1. Créer un lien full et un lien light, générer le lien par défaut → 200 ; ouvrir les pages publiques (trigramme sur la full) → contenu affiché.
2. Partage par mail → mail Brevo 89 reçu, quota 10/24h inchangé ; renvoi (`/links/{id}/resend`) et réactivation d'un lien → 200.
3. Contre-test : dossier `TO_PROCESS` ou `INCOMPLETE` → création lien/mail → **409**.

**Full PDF**
4. `POST /api/application/fullPdf/{token}` sur le dossier COMPLETED → génération ; le PDF ne contient **ni page de garde ni index**, s'ouvre sur « Le mot du locataire » (si renseigné) et **aucune page ne porte les logos RF/DossierFacile** ; signets par pièce présents.
5. Dossier `VALIDATED` : PDF **identique à la prod** (page de garde, index, logos).
6. Invalidation : PDF COMPLETED généré, puis opt-in « oui » → `GET fullPdf` → 409/417 (PDF supprimé) ; après validation opérateur, régénération au rendu historique.
7. Liaison DFC pendant COMPLETED → bascule `TO_PROCESS`, le lien partagé reste actif (page publique en rendu « en cours de vérification »), PDF invalidé.

**Opt-out des dossiers examinés**
8. Dossier validé après opt-in (`validation_requested=true`) → modifier un document → re-signature → `TO_PROCESS` (le choix persiste) ; encart « annuler ma demande » présent → annulation → `COMPLETED`.
9. `PUT /api/tenant/validation-request {false}` sur un dossier `VALIDATED` → 200, statut inchangé, log `VALIDATION_DECLINED` ; puis modification + re-signature → `COMPLETED` direct (mail 173).
10. Dossier `DECLINED` corrigé avec choix `false`/`null` → re-soumission → `COMPLETED`.
11. Non-régression hors rollout : soumission → `TO_PROCESS`, pas d'encart, mail 56.

**Invariants partenaires**
12. SQL : `callback_log.tenant_status` sans `COMPLETED` ; ELK : zéro occurrence de « Defensive status masking triggered ».

## Coordination
- Wording du template Brevo 89 à adapter côté Brevo (couvre désormais les dossiers non vérifiés).
v