### PR TITLE
feat(doc-ia): add analysis for pnds proffessional activity

### DIFF
--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/DocumentRule.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/DocumentRule.java
@@ -261,6 +261,18 @@ public enum DocumentRule {
             "La taxe foncière n'est pas de l'année requise",
             "La taxe foncière est de l'année requise",
             "Impossible de vérifier l'année de la taxe foncière"
+    ),
+    R_PROFESSIONAL_2DDOC_ISSUE_DATE(
+            DocumentRuleLevel.CRITICAL,
+            "Le document d'activité professionnelle a été émis il y a plus de 2 mois",
+            "Le document d'activité professionnelle a été émis il y a moins de 2 mois",
+            "Impossible de vérifier la date d'émission du document d'activité professionnelle"
+    ),
+    R_PROFESSIONAL_NAME_MATCH(
+            DocumentRuleLevel.CRITICAL,
+            "Le nom et le prénom sur le document d'activité professionnelle ne correspondent pas",
+            "Le nom et le prénom sur le document d'activité professionnelle correspondent",
+            "Impossible de vérifier le nom et le prénom sur le document d'activité professionnelle"
     );
 
     private final DocumentRuleLevel level;

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/BarcodeModel.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/model/document_ia/BarcodeModel.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import javax.annotation.Nullable;
 import java.io.Serial;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.List;
 
 @Data
@@ -36,4 +37,6 @@ public class BarcodeModel implements Serializable {
     private String antsType;
     @JsonProperty("doc_type")
     private String docType;
+    @JsonProperty("issue_date")
+    private LocalDate issueDate;
 }

--- a/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
+++ b/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
@@ -205,4 +205,5 @@
     <include file="db/migration/20260723160000-add-ready-for-auto-validation-to-tenant.xml"/>
     <include file="db/migration/20260731140000-update-ranked-tenant-exclude-auto-validation.xml"/>
     <include file="db/migration/20260806000000-add-completed-optin.xml"/>
+    <include file="db/migration/202608270000-add-document-ia-professional-analysis-flag.xml"/>
 </databaseChangeLog>

--- a/dossierfacile-common-library/src/main/resources/db/migration/202608270000-add-document-ia-professional-analysis-flag.xml
+++ b/dossierfacile-common-library/src/main/resources/db/migration/202608270000-add-document-ia-professional-analysis-flag.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
+    <changeSet id="202608270000" author="nsagon">
+        <insert tableName="feature_flag">
+            <column name="key" value="document-ia-professional-analysis"/>
+            <column name="description" value="Enable Document IA analysis for professional documents (CDI, CDD, Alternation, Internship, Intermittent)"/>
+            <column name="active" valueBoolean="false"/>
+            <column name="only_for_new_user" valueBoolean="false"/>
+            <column name="rollout_pct" valueNumeric="0"/>
+        </insert>
+
+        <rollback>
+            <delete tableName="feature_flag">
+                <where>key = 'document-ia-professional-analysis'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/DocumentIAConfig.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/DocumentIAConfig.java
@@ -5,6 +5,7 @@ import fr.dossierfacile.common.enums.DocumentCategoryStep;
 import fr.dossierfacile.common.enums.DocumentSubCategory;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.document.analysis.external.documentia.WorkflowV2StepParamOverride;
+import fr.dossierfacile.document.analysis.rule.ProfessionalRulesValidationService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,6 +30,7 @@ public class DocumentIAConfig {
     private static final String FEATURE_FLAG_SALARY_MORE_3_MONTHS_ANALYSIS_KEY = "document-ia-salary-more-3-months-analysis";
     private static final String FEATURE_FLAG_RESIDENCY_ANALYSIS_KEY = "document-ia-residency-classification";
     private static final String FEATURE_FLAG_PROPERTY_TAX_ANALYSIS_KEY = "document-ia-property-tax-analysis";
+    private static final String FEATURE_FLAG_PROFESSIONAL_ANALYSIS_KEY = "document-ia-professional-analysis";
 
     @Data
     public static class WorkflowConfig {
@@ -68,12 +70,18 @@ public class DocumentIAConfig {
             return featureFlagService.isFeatureEnabledForUser(tenantId, FEATURE_FLAG_RESIDENCY_ANALYSIS_KEY);
         }
 
+        if (ProfessionalRulesValidationService.PROFESSIONAL_SUB_CATEGORIES.contains(document.getDocumentSubCategory())) {
+            return featureFlagService.isFeatureEnabledForUser(tenantId, FEATURE_FLAG_PROFESSIONAL_ANALYSIS_KEY);
+        }
+
         return false;
     }
 
     public WorkflowConfig getWorkflowConfig(Document document) {
         return switch (document.getDocumentSubCategory()) {
             case MY_NAME -> new WorkflowConfig("document-barcode-extraction-v2");
+            // Professional subtypes
+            case CDI, CDD, ALTERNATION, INTERNSHIP, INTERMITTENT -> new WorkflowConfig("document-barcode-extraction-v2");
             case TENANT, GUEST -> new WorkflowConfig("document-classification-v2", Map.of(
                     "extract_content_ocr", List.of(new WorkflowV2StepParamOverride("model", "tesseract"))
             ));

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/ProfessionalRulesValidationService.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/ProfessionalRulesValidationService.java
@@ -1,0 +1,40 @@
+package fr.dossierfacile.document.analysis.rule;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.enums.DocumentSubCategory;
+import fr.dossierfacile.document.analysis.rule.validator.AbstractDocumentRuleValidator;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.HasBeenDocumentIAAnalysedBI;
+import fr.dossierfacile.document.analysis.rule.validator.professional.Professional2DDocIssueDateRule;
+import fr.dossierfacile.document.analysis.rule.validator.professional.ProfessionalClassificationRuleBI;
+import fr.dossierfacile.document.analysis.rule.validator.professional.ProfessionalNamesRule;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProfessionalRulesValidationService extends AbstractRulesValidationService {
+
+    public static final Set<DocumentSubCategory> PROFESSIONAL_SUB_CATEGORIES = EnumSet.of(
+            DocumentSubCategory.CDI,
+            DocumentSubCategory.CDD,
+            DocumentSubCategory.ALTERNATION,
+            DocumentSubCategory.INTERNSHIP,
+            DocumentSubCategory.INTERMITTENT
+    );
+
+    @Override
+    List<AbstractDocumentRuleValidator> getDocumentRuleValidators(Document document) {
+        return List.of(
+                new HasBeenDocumentIAAnalysedBI(),
+                new ProfessionalClassificationRuleBI(),
+                new Professional2DDocIssueDateRule(),
+                new ProfessionalNamesRule()
+        );
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/Professional2DDocIssueDateRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/Professional2DDocIssueDateRule.java
@@ -1,0 +1,121 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentAnalysisRule;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.entity.rule.ExpirationRuleData;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/*
+ * Rule R_PROFESSIONAL_2DDOC_ISSUE_DATE (Professional 2D-Doc issue date rule):
+ *
+ * Cette règle vérifie la date d'émission (`issue_date`) du 2D-Doc (type `29`) présent sur le document professionnel.
+ *
+ * Données examinées:
+ * - La propriété `issue_date` du premier 2D-Doc de type `29` trouvé dans les analyses Document-IA réussies.
+ *
+ * Fonctionnement:
+ * - Filtre et récupère la date d'émission (`issue_date`) du premier barcode 2D-Doc de type `29`.
+ * - Si aucune analyse IA réussie, aucun 2D-Doc de type `29` ou aucune date d'émission n'est disponible -> retourne INCONCLUSIVE.
+ * - Vérifie que la date d'émission est située entre il y a 2 mois et aujourd'hui (`LocalDate.now(clock)`).
+ * - Si la date d'émission respecte cet intervalle -> retourne PASSED avec ExpirationRuleData.
+ * - Si la date d'émission est antérieure à 2 mois ou située dans le futur -> retourne FAILED avec ExpirationRuleData.
+ * - Le seuil de 2 mois est configurable via la variable statique `MAXIMUM_AGE_IN_MONTHS`.
+ */
+public class Professional2DDocIssueDateRule extends BaseDocumentIAValidator {
+
+    public static final int MAXIMUM_AGE_IN_MONTHS = 2;
+    private static final String EXPECTED_DOC_TYPE = "29";
+
+    private final Clock clock;
+
+    public Professional2DDocIssueDateRule() {
+        this(Clock.systemDefaultZone());
+    }
+
+    public Professional2DDocIssueDateRule(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    protected boolean isBlocking() {
+        return false;
+    }
+
+    @Override
+    protected boolean isInconclusive() {
+        return true;
+    }
+
+    @Override
+    protected DocumentRule getRule() {
+        return DocumentRule.R_PROFESSIONAL_2DDOC_ISSUE_DATE;
+    }
+
+    @Override
+    public RuleValidatorOutput validate(Document document) {
+        var documentIAAnalyses = this.getSuccessfulDocumentIAAnalyses(document);
+        var issueDateOpt = extractIssueDate(documentIAAnalyses);
+
+        if (issueDateOpt.isEmpty()) {
+            return new RuleValidatorOutput(
+                    false,
+                    isBlocking(),
+                    DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), null),
+                    RuleValidatorOutput.RuleLevel.INCONCLUSIVE
+            );
+        }
+
+        LocalDate issueDate = issueDateOpt.get();
+        ExpirationRuleData ruleData = new ExpirationRuleData(issueDate);
+
+        if (isIssueDateValid(issueDate)) {
+            return new RuleValidatorOutput(
+                    true,
+                    isBlocking(),
+                    DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), ruleData),
+                    RuleValidatorOutput.RuleLevel.PASSED
+            );
+        } else {
+            return new RuleValidatorOutput(
+                    false,
+                    isBlocking(),
+                    DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), ruleData),
+                    RuleValidatorOutput.RuleLevel.FAILED
+            );
+        }
+    }
+
+    private Optional<LocalDate> extractIssueDate(List<DocumentIAFileAnalysis> documentIAAnalyses) {
+        return documentIAAnalyses.stream()
+                .map(DocumentIAFileAnalysis::getResult)
+                .filter(Objects::nonNull)
+                .filter(result -> result.getBarcodes() != null)
+                .flatMap(result -> result.getBarcodes().stream())
+                .filter(Objects::nonNull)
+                .filter(barcode -> EXPECTED_DOC_TYPE.equals(barcode.getDocType()))
+                .map(BarcodeModel::getIssueDate)
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    private boolean isIssueDateValid(LocalDate issueDate) {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate threshold = today.minusMonths(MAXIMUM_AGE_IN_MONTHS);
+        return !issueDate.isBefore(threshold) && !issueDate.isAfter(today);
+    }
+
+    @Override
+    protected boolean isValid(Document document) {
+        return false;
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalClassificationRuleBI.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalClassificationRuleBI.java
@@ -1,0 +1,67 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+
+/*
+ * Rule R_DOCUMENT_IA_CLASSIFICATION (Professional classification variant BI):
+ *
+ * Cette règle vérifie la classification du document professionnel via 2D-Doc.
+ *
+ * Données examinées:
+ * - Les barcodes du document issus des analyses Document-IA réussies.
+ * - Le type de 2D-Doc (`doc_type`).
+ *
+ * Fonctionnement:
+ * - Vérifie qu'au moins un barcode 2D-Doc possède un `doc_type` égal à "29" (Attestation d'activité professionnelle).
+ * - Retourne PASSED si un tel 2D-Doc est présent.
+ * - Retourne INCONCLUSIVE et BLOQUANT sinon (générant un statut d'analyse UNDEFINED).
+ */
+public class ProfessionalClassificationRuleBI extends BaseDocumentIAValidator {
+
+    private static final String EXPECTED_DOC_TYPE = "29";
+
+    @Override
+    protected boolean isBlocking() {
+        return true;
+    }
+
+    @Override
+    protected boolean isInconclusive() {
+        return true;
+    }
+
+    @Override
+    protected DocumentRule getRule() {
+        return DocumentRule.R_DOCUMENT_IA_CLASSIFICATION;
+    }
+
+    @Override
+    protected boolean isValid(Document document) {
+        var documentIAAnalyses = this.getSuccessfulDocumentIAAnalyses(document);
+        if (documentIAAnalyses.isEmpty()) {
+            return false;
+        }
+
+        for (var analysis : documentIAAnalyses) {
+            if (analysis.getResult() != null && analysis.getResult().getBarcodes() != null) {
+                for (BarcodeModel barcode : analysis.getResult().getBarcodes()) {
+                    if (isType29Barcode(barcode)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isType29Barcode(BarcodeModel barcode) {
+        if (barcode == null) {
+            return false;
+        }
+        return EXPECTED_DOC_TYPE.equals(barcode.getDocType());
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalNamesRule.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalNamesRule.java
@@ -1,0 +1,171 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentAnalysisRule;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.DocumentRule;
+import fr.dossierfacile.common.entity.rule.NamesRuleData;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.common.model.document_ia.GenericProperty;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.BaseDocumentIAValidator;
+import fr.dossierfacile.document.analysis.rule.validator.util.IdentityMatchUtil;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/*
+ * Rule R_PROFESSIONAL_NAME_MATCH:
+ *
+ * Cette règle vérifie que l'identité présente dans le 2D-Doc d'un document d'activité professionnelle
+ * correspond à l'identité du locataire (ou du garant si le document lui appartient).
+ *
+ * Données examinées:
+ * - Les propriétés `liste_prenoms` et `nom_patronymique` contenues dans les barcodes 2D-Doc du document.
+ * - L'identité attendue du locataire ou du garant (`firstName`, `lastName`, `preferredName`).
+ *
+ * Fonctionnement:
+ * 1) Récupération de l'identité du locataire ou garant rattaché au document (`getNamesFromDocument`).
+ * 2) Extraction des identités des barcodes 2D-Doc à partir de `liste_prenoms` et `nom_patronymique`.
+ * 3) Si aucune analyse réussie, aucun barcode exploitable ou identité manquante -> retourne INCONCLUSIVE.
+ * 4) Comparaison du nom de famille (nom de naissance + nom d'usage) via `IdentityMatchUtil.hasLastNameMatch`.
+ * 5) Comparaison des prénoms via `IdentityMatchUtil.hasFirstNameMatch`.
+ * 6) Si nom ET prénom correspondent -> retourne PASSED.
+ * 7) Sinon -> retourne FAILED.
+ */
+public class ProfessionalNamesRule extends BaseDocumentIAValidator {
+
+    private static final String EXPECTED_DOC_TYPE = "29";
+
+    @Override
+    protected boolean isBlocking() {
+        return false;
+    }
+
+    @Override
+    protected boolean isInconclusive() {
+        return true;
+    }
+
+    @Override
+    protected DocumentRule getRule() {
+        return DocumentRule.R_PROFESSIONAL_NAME_MATCH;
+    }
+
+    @Override
+    public RuleValidatorOutput validate(Document document) {
+        var documentIAAnalyses = this.getSuccessfulDocumentIAAnalyses(document);
+
+        var nameToMatch = getNamesFromDocument(document);
+
+        NamesRuleData namesRuleData = null;
+        if (nameToMatch != null) {
+            var expectedName = new NamesRuleData.Name(
+                    nameToMatch.getFirstNamesAsString(),
+                    nameToMatch.getLastName(),
+                    nameToMatch.getPreferredName()
+            );
+
+            namesRuleData = new NamesRuleData(expectedName, List.of());
+        }
+
+        var barcodes = documentIAAnalyses.stream()
+                .map(DocumentIAFileAnalysis::getResult)
+                .filter(Objects::nonNull)
+                .filter(result -> result.getBarcodes() != null)
+                .flatMap(result -> result.getBarcodes().stream())
+                .filter(Objects::nonNull)
+                .filter(barcode -> EXPECTED_DOC_TYPE.equals(barcode.getDocType()))
+                .toList();
+
+        if (barcodes.isEmpty() || nameToMatch == null) {
+            return new RuleValidatorOutput(
+                    false,
+                    isBlocking(),
+                    DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData),
+                    RuleValidatorOutput.RuleLevel.INCONCLUSIVE
+            );
+        }
+
+        var extractedNames = barcodes.stream()
+                .map(this::convertBarcodeModelToExtractedName)
+                .flatMap(Optional::stream)
+                .distinct()
+                .toList();
+
+        var listOfBarcodeIdentities = extractedNames.stream()
+                .map(name -> (name.firstNames() + " " + name.lastName()).trim())
+                .filter(s -> !s.isBlank())
+                .toList();
+
+        namesRuleData = new NamesRuleData(namesRuleData != null ? namesRuleData.expectedName() : null, extractedNames);
+
+        if (listOfBarcodeIdentities.isEmpty()) {
+            return new RuleValidatorOutput(
+                    false,
+                    isBlocking(),
+                    DocumentAnalysisRule.documentInconclusiveRuleFromWithData(getRule(), namesRuleData),
+                    RuleValidatorOutput.RuleLevel.INCONCLUSIVE
+            );
+        }
+
+        var hasLastNameMatch = IdentityMatchUtil.hasLastNameMatch(listOfBarcodeIdentities, nameToMatch);
+        if (!hasLastNameMatch) {
+            return reject(namesRuleData);
+        }
+
+        var hasFirstNameMatch = IdentityMatchUtil.hasFirstNameMatch(listOfBarcodeIdentities, nameToMatch);
+        if (!hasFirstNameMatch) {
+            return reject(namesRuleData);
+        }
+
+        return new RuleValidatorOutput(
+                true,
+                isBlocking(),
+                DocumentAnalysisRule.documentPassedRuleFromWithData(getRule(), namesRuleData),
+                RuleValidatorOutput.RuleLevel.PASSED
+        );
+    }
+
+    private RuleValidatorOutput reject(NamesRuleData ruleData) {
+        return new RuleValidatorOutput(
+                false,
+                isBlocking(),
+                DocumentAnalysisRule.documentFailedRuleFromWithData(getRule(), ruleData),
+                RuleValidatorOutput.RuleLevel.FAILED
+        );
+    }
+
+    @Override
+    protected boolean isValid(Document document) {
+        return false;
+    }
+
+    private Optional<NamesRuleData.Name> convertBarcodeModelToExtractedName(BarcodeModel barcodeModel) {
+        if (barcodeModel == null || barcodeModel.getTypedData() == null) {
+            return Optional.empty();
+        }
+
+        var listePrenoms = barcodeModel.getTypedData().stream()
+                .filter(data -> data != null && "liste_prenoms".equals(data.getName()))
+                .map(GenericProperty::getStringValue)
+                .filter(Objects::nonNull)
+                .findFirst();
+
+        var nomPatronymique = barcodeModel.getTypedData().stream()
+                .filter(data -> data != null && "nom_patronymique".equals(data.getName()))
+                .map(GenericProperty::getStringValue)
+                .filter(Objects::nonNull)
+                .findFirst();
+
+        if (listePrenoms.isEmpty() && nomPatronymique.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String prenom = listePrenoms.orElse("");
+        String nom = nomPatronymique.orElse("");
+
+        return Optional.of(new NamesRuleData.Name(prenom, nom, null));
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/document_ia_model/PNDSProfessionalActivity2DDoc.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/rule/validator/professional/document_ia_model/PNDSProfessionalActivity2DDoc.java
@@ -1,0 +1,36 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional.document_ia_model;
+
+import fr.dossierfacile.common.enums.DocumentCategory;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAField;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.mapper.DocumentIAModel;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+// This model is used to sanitize the 2DDoc content of a Professional document (PNDS)
+@Setter
+@DocumentIAModel(documentCategory = DocumentCategory.PROFESSIONAL)
+public class PNDSProfessionalActivity2DDoc {
+
+    @DocumentIAField(twoDDocName = "doc_type")
+    public String docType;
+
+    @DocumentIAField(twoDDocName = "date_debut_contrat")
+    public LocalDate dateDebutContrat;
+
+    @DocumentIAField(twoDDocName = "periode_declaration_contrat")
+    public String periodeDeclarationContrat;
+
+    @DocumentIAField(twoDDocName = "liste_prenoms")
+    public String listePrenoms;
+
+    @DocumentIAField(twoDDocName = "nom_patronymique")
+    public String nomPatronymique;
+
+    @DocumentIAField(twoDDocName = "nature_contrat")
+    public String natureContrat;
+
+    public PNDSProfessionalActivity2DDoc() {
+        // Intentionally empty: required for reflection-based instantiation by DocumentIA mapper
+    }
+}

--- a/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/service/DocumentAnalysisServiceConfiguration.java
+++ b/dossierfacile-document-analysis/src/main/java/fr/dossierfacile/document/analysis/service/DocumentAnalysisServiceConfiguration.java
@@ -17,13 +17,18 @@ public class DocumentAnalysisServiceConfiguration {
             CarteNationalIdentiteRulesValidationService carteNationalIdentiteRulesValidationService,
             BulletinSalaireRulesValidationService bulletinSalaireRulesValidationService,
             AvisImpositionRulesValidationService avisImpositionRulesValidationService,
-            VisaleCertificateRulesValidationService visaleCertificateRulesValidationService
+            VisaleCertificateRulesValidationService visaleCertificateRulesValidationService,
+            ProfessionalRulesValidationService professionalRulesValidationService
     ) {
         EnumMap<DocumentSubCategory, AbstractRulesValidationService> validators = new EnumMap<>(DocumentSubCategory.class);
         validators.put(DocumentSubCategory.FRENCH_IDENTITY_CARD, carteNationalIdentiteRulesValidationService);
         validators.put(DocumentSubCategory.SALARY, bulletinSalaireRulesValidationService);
         validators.put(DocumentSubCategory.MY_NAME, avisImpositionRulesValidationService);
         validators.put(DocumentSubCategory.VISALE, visaleCertificateRulesValidationService);
+
+        // Professional documents (CDI, CDD, ALTERNATION, INTERNSHIP, INTERMITTENT)
+        ProfessionalRulesValidationService.PROFESSIONAL_SUB_CATEGORIES
+                .forEach(it -> validators.put(it, professionalRulesValidationService));
 
         // Property tax notice (taxe foncière, document category RESIDENCY/OWNER). has its own dedicated rules with strict classification.
         validators.put(DocumentSubCategory.OWNER, new PropertyTaxRulesValidationService());

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/DocumentIAConfigTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/DocumentIAConfigTest.java
@@ -1,0 +1,60 @@
+package fr.dossierfacile.document.analysis;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.enums.DocumentSubCategory;
+import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentIAConfigTest {
+
+    @Mock
+    private FeatureFlagService featureFlagService;
+
+    @InjectMocks
+    private DocumentIAConfig documentIAConfig;
+
+    private static final long TENANT_ID = 123L;
+
+    @ParameterizedTest
+    @EnumSource(value = DocumentSubCategory.class, names = {"CDI", "CDD", "ALTERNATION", "INTERNSHIP", "INTERMITTENT"})
+    void should_send_for_analysis_when_professional_feature_flag_is_enabled(DocumentSubCategory subCategory) {
+        Document document = Document.builder().documentSubCategory(subCategory).build();
+        when(featureFlagService.isFeatureEnabledForUser(TENANT_ID, "document-ia-professional-analysis")).thenReturn(true);
+
+        boolean result = documentIAConfig.hasToSendFileForAnalysis(document, TENANT_ID);
+
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DocumentSubCategory.class, names = {"CDI", "CDD", "ALTERNATION", "INTERNSHIP", "INTERMITTENT"})
+    void should_not_send_for_analysis_when_professional_feature_flag_is_disabled(DocumentSubCategory subCategory) {
+        Document document = Document.builder().documentSubCategory(subCategory).build();
+        when(featureFlagService.isFeatureEnabledForUser(TENANT_ID, "document-ia-professional-analysis")).thenReturn(false);
+
+        boolean result = documentIAConfig.hasToSendFileForAnalysis(document, TENANT_ID);
+
+        assertThat(result).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = DocumentSubCategory.class, names = {"CDI", "CDD", "ALTERNATION", "INTERNSHIP", "INTERMITTENT", "MY_NAME"})
+    void should_return_barcode_workflow_for_professional_and_tax_documents(DocumentSubCategory subCategory) {
+        Document document = Document.builder().documentSubCategory(subCategory).build();
+
+        DocumentIAConfig.WorkflowConfig workflowConfig = documentIAConfig.getWorkflowConfig(document);
+
+        assertThat(workflowConfig.getWorkflowId()).isEqualTo("document-barcode-extraction-v2");
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/ProfessionalRulesValidationServiceTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/ProfessionalRulesValidationServiceTest.java
@@ -1,0 +1,37 @@
+package fr.dossierfacile.document.analysis.rule;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.enums.DocumentSubCategory;
+import fr.dossierfacile.document.analysis.rule.validator.AbstractDocumentRuleValidator;
+import fr.dossierfacile.document.analysis.rule.validator.document_ia.HasBeenDocumentIAAnalysedBI;
+import fr.dossierfacile.document.analysis.rule.validator.professional.Professional2DDocIssueDateRule;
+import fr.dossierfacile.document.analysis.rule.validator.professional.ProfessionalClassificationRuleBI;
+import fr.dossierfacile.document.analysis.rule.validator.professional.ProfessionalNamesRule;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfessionalRulesValidationServiceTest {
+
+    private final ProfessionalRulesValidationService service = new ProfessionalRulesValidationService();
+
+    @ParameterizedTest
+    @EnumSource(value = DocumentSubCategory.class, names = {"CDI", "CDD", "ALTERNATION", "INTERNSHIP", "INTERMITTENT"})
+    void should_return_header_validators_for_professional_subcategories(DocumentSubCategory subCategory) {
+        Document document = Document.builder()
+                .documentSubCategory(subCategory)
+                .build();
+
+        List<AbstractDocumentRuleValidator> validators = service.getDocumentRuleValidators(document);
+
+        assertThat(validators).hasExactlyElementsOfTypes(
+                HasBeenDocumentIAAnalysedBI.class,
+                ProfessionalClassificationRuleBI.class,
+                Professional2DDocIssueDateRule.class,
+                ProfessionalNamesRule.class
+        );
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/Professional2DDocIssueDateRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/Professional2DDocIssueDateRuleTest.java
@@ -1,0 +1,191 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.common.model.document_ia.ResultModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Professional2DDocIssueDateRuleTest {
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-08-27T12:00:00Z"), ZoneId.of("UTC"));
+    private final Professional2DDocIssueDateRule rule = new Professional2DDocIssueDateRule(fixedClock);
+
+    @Test
+    void should_pass_when_issue_date_is_within_2_months() {
+        // Given - 1 month ago (within 2 months limit)
+        LocalDate recentDate = LocalDate.now(fixedClock).minusMonths(1);
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(recentDate)
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    void should_pass_when_issue_date_is_today() {
+        // Given
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(LocalDate.now(fixedClock))
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    void should_pass_when_issue_date_is_exactly_2_months_ago() {
+        // Given - exactly 2 months ago (boundary case)
+        LocalDate boundaryDate = LocalDate.now(fixedClock).minusMonths(2);
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(boundaryDate)
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    void should_be_failed_when_issue_date_is_older_than_2_months() {
+        // Given - 3 months ago (exceeds 2 months limit)
+        LocalDate oldDate = LocalDate.now(fixedClock).minusMonths(3);
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(oldDate)
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+
+    @Test
+    void should_be_failed_when_issue_date_is_in_the_future() {
+        // Given - 2 days in the future
+        LocalDate futureDate = LocalDate.now(fixedClock).plusDays(2);
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(futureDate)
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+    }
+
+    @Test
+    void should_ignore_non_type_29_barcodes_and_evaluate_type_29_barcode() {
+        // Given - First barcode is type "10" (non-PNDS) with an old issueDate; Second is type "29" (PNDS) with recent issueDate
+        BarcodeModel nonType29Barcode = BarcodeModel.builder()
+                .docType("10")
+                .issueDate(LocalDate.now(fixedClock).minusMonths(6))
+                .build();
+
+        BarcodeModel type29Barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(LocalDate.now(fixedClock).minusMonths(1))
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(nonType29Barcode, type29Barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+    }
+
+    @Test
+    void should_be_inconclusive_when_issue_date_is_null() {
+        // Given
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .issueDate(null)
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    @Test
+    void should_be_inconclusive_when_no_successful_analysis() {
+        // Given
+        Document document = Document.builder()
+                .files(List.of(
+                        File.builder()
+                                .documentIAFileAnalysis(DocumentIAFileAnalysis.builder()
+                                        .analysisStatus(DocumentIAFileAnalysisStatus.FAILED)
+                                        .build())
+                                .build()
+                ))
+                .build();
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+    }
+
+    private Document buildDocumentWithBarcodes(List<BarcodeModel> barcodes) {
+        ResultModel resultModel = ResultModel.builder()
+                .barcodes(barcodes)
+                .build();
+
+        DocumentIAFileAnalysis analysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(resultModel)
+                .build();
+
+        File file = File.builder()
+                .documentIAFileAnalysis(analysis)
+                .build();
+
+        return Document.builder()
+                .files(List.of(file))
+                .build();
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalClassificationRuleBITest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalClassificationRuleBITest.java
@@ -1,0 +1,125 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.Document;
+import fr.dossierfacile.common.entity.DocumentIAFileAnalysis;
+import fr.dossierfacile.common.entity.File;
+import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.common.model.document_ia.ResultModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfessionalClassificationRuleBITest {
+
+    private final ProfessionalClassificationRuleBI rule = new ProfessionalClassificationRuleBI();
+
+    @Test
+    void should_pass_when_at_least_one_barcode_has_doc_type_29() {
+        // Given
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.isBlocking()).isTrue();
+    }
+
+    @Test
+    void should_pass_when_multiple_barcodes_and_one_is_doc_type_29() {
+        // Given - First barcode non-29, second barcode type 29
+        BarcodeModel barcode1 = BarcodeModel.builder().docType("10").build();
+        BarcodeModel barcode2 = BarcodeModel.builder().docType("29").build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode1, barcode2));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.isBlocking()).isTrue();
+    }
+
+    @Test
+    void should_be_inconclusive_and_blocking_when_no_barcode_has_doc_type_29() {
+        // Given
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("27")
+                .build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(output.isBlocking()).isTrue();
+    }
+
+    @Test
+    void should_be_inconclusive_and_blocking_when_doc_type_is_null_or_empty() {
+        // Given
+        BarcodeModel barcode1 = BarcodeModel.builder().docType(null).build();
+        BarcodeModel barcode2 = BarcodeModel.builder().docType("").build();
+
+        Document document = buildDocumentWithBarcodes(List.of(barcode1, barcode2));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(output.isBlocking()).isTrue();
+    }
+
+    @Test
+    void should_be_inconclusive_and_blocking_when_no_successful_analysis() {
+        // Given
+        Document document = Document.builder()
+                .files(List.of(
+                        File.builder()
+                                .documentIAFileAnalysis(DocumentIAFileAnalysis.builder()
+                                        .analysisStatus(DocumentIAFileAnalysisStatus.FAILED)
+                                        .build())
+                                .build()
+                ))
+                .build();
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(output.isBlocking()).isTrue();
+    }
+
+    private Document buildDocumentWithBarcodes(List<BarcodeModel> barcodes) {
+        ResultModel resultModel = ResultModel.builder()
+                .barcodes(barcodes)
+                .build();
+
+        DocumentIAFileAnalysis analysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(resultModel)
+                .build();
+
+        File file = File.builder()
+                .documentIAFileAnalysis(analysis)
+                .build();
+
+        return Document.builder()
+                .files(List.of(file))
+                .build();
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalNamesRuleTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/rule/validator/professional/ProfessionalNamesRuleTest.java
@@ -1,0 +1,325 @@
+package fr.dossierfacile.document.analysis.rule.validator.professional;
+
+import fr.dossierfacile.common.entity.*;
+import fr.dossierfacile.common.entity.rule.NamesRuleData;
+import fr.dossierfacile.common.enums.DocumentIAFileAnalysisStatus;
+import fr.dossierfacile.common.model.document_ia.BarcodeModel;
+import fr.dossierfacile.common.model.document_ia.GenericProperty;
+import fr.dossierfacile.common.model.document_ia.ResultModel;
+import fr.dossierfacile.document.analysis.rule.validator.RuleValidatorOutput;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfessionalNamesRuleTest {
+
+    private final ProfessionalNamesRule rule = new ProfessionalNamesRule();
+
+    @Test
+    void should_pass_when_tenant_name_matches_2ddoc() {
+        // Given
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_pass_when_guarantor_name_matches_2ddoc() {
+        // Given
+        Guarantor guarantor = Guarantor.builder()
+                .firstName("DIALLA BAH")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithGuarantor(guarantor, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_pass_when_preferred_name_matches_2ddoc() {
+        // Given - Tenant has preferredName "KONATE" while birth lastName is "DIALLO"
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("DIALLO")
+                .preferredName("KONATE")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_deduplicate_identical_extracted_names_from_multiple_2ddocs() {
+        // Given - 2 barcodes with identical extracted name
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode1 = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        BarcodeModel barcode2 = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode1, barcode2));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        NamesRuleData ruleData = (NamesRuleData) output.rule().getRuleData();
+        assertThat(ruleData.extractedNames()).hasSize(1);
+        assertThat(ruleData.extractedNames().get(0).firstNames()).isEqualTo("DIALLA BAH");
+        assertThat(ruleData.extractedNames().get(0).lastName()).isEqualTo("KONATE");
+    }
+
+    @Test
+    void should_keep_distinct_extracted_names_from_multiple_2ddocs() {
+        // Given - 2 barcodes with 2 different extracted names
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode1 = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        BarcodeModel barcode2 = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("JEAN").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("DUPONT").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode1, barcode2));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.PASSED);
+        NamesRuleData ruleData = (NamesRuleData) output.rule().getRuleData();
+        assertThat(ruleData.extractedNames()).hasSize(2);
+    }
+
+    @Test
+    void should_fail_when_firstname_matches_but_lastname_does_not() {
+        // Given
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("SMITH")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_fail_when_lastname_matches_but_firstname_does_not() {
+        // Given
+        Tenant tenant = Tenant.builder()
+                .firstName("JEAN")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.FAILED);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_be_inconclusive_when_neither_tenant_nor_guarantor_attached() {
+        // Given - Document with no Tenant and no Guarantor
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of(
+                        GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                        GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build()
+                ))
+                .build();
+
+        Document document = buildDocumentWithBarcodesOnly(List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    @Test
+    void should_be_inconclusive_when_no_barcode_identities() {
+        // Given
+        Tenant tenant = Tenant.builder()
+                .firstName("DIALLA BAH")
+                .lastName("KONATE")
+                .build();
+
+        BarcodeModel barcode = BarcodeModel.builder()
+                .docType("29")
+                .typedData(List.of())
+                .build();
+
+        Document document = buildDocumentWithTenant(tenant, List.of(barcode));
+
+        // When
+        RuleValidatorOutput output = rule.validate(document);
+
+        // Then
+        assertThat(output.ruleLevel()).isEqualTo(RuleValidatorOutput.RuleLevel.INCONCLUSIVE);
+        assertThat(output.isBlocking()).isFalse();
+    }
+
+    private Document buildDocumentWithTenant(Tenant tenant, List<BarcodeModel> barcodes) {
+        ResultModel resultModel = ResultModel.builder()
+                .barcodes(barcodes)
+                .build();
+
+        DocumentIAFileAnalysis analysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(resultModel)
+                .build();
+
+        File file = File.builder()
+                .documentIAFileAnalysis(analysis)
+                .build();
+
+        return Document.builder()
+                .tenant(tenant)
+                .files(List.of(file))
+                .build();
+    }
+
+    private Document buildDocumentWithGuarantor(Guarantor guarantor, List<BarcodeModel> barcodes) {
+        ResultModel resultModel = ResultModel.builder()
+                .barcodes(barcodes)
+                .build();
+
+        DocumentIAFileAnalysis analysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(resultModel)
+                .build();
+
+        File file = File.builder()
+                .documentIAFileAnalysis(analysis)
+                .build();
+
+        return Document.builder()
+                .guarantor(guarantor)
+                .files(List.of(file))
+                .build();
+    }
+
+    private Document buildDocumentWithBarcodesOnly(List<BarcodeModel> barcodes) {
+        ResultModel resultModel = ResultModel.builder()
+                .barcodes(barcodes)
+                .build();
+
+        DocumentIAFileAnalysis analysis = DocumentIAFileAnalysis.builder()
+                .analysisStatus(DocumentIAFileAnalysisStatus.SUCCESS)
+                .result(resultModel)
+                .build();
+
+        File file = File.builder()
+                .documentIAFileAnalysis(analysis)
+                .build();
+
+        return Document.builder()
+                .files(List.of(file))
+                .build();
+    }
+}

--- a/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/service/DocumentIAResultSanitizerTest.java
+++ b/dossierfacile-document-analysis/src/test/java/fr/dossierfacile/document/analysis/service/DocumentIAResultSanitizerTest.java
@@ -195,6 +195,47 @@ class DocumentIAResultSanitizerTest {
         }
 
         @Test
+        void should_keep_allowed_typed_data_for_professional_2ddoc() {
+            DocumentIAResultSanitizer sanitizer = newSanitizer(List.of(fr.dossierfacile.document.analysis.rule.validator.professional.document_ia_model.PNDSProfessionalActivity2DDoc.class));
+
+            Document professionalDoc = new Document();
+            professionalDoc.setDocumentCategory(DocumentCategory.PROFESSIONAL);
+            professionalDoc.setDocumentSubCategory(DocumentSubCategory.CDI);
+
+            ResultModel input = ResultModel.builder()
+                    .barcodes(List.of(
+                            BarcodeModel.builder()
+                                    .rawData(buildSampleRawData("REF", "DIALLA BAH KONATE"))
+                                    .typedData(List.of(
+                                            GenericProperty.builder().name("doc_type").type(GenericProperty.TYPE_STRING).value("29").build(),
+                                            GenericProperty.builder().name("date_debut_contrat").type(GenericProperty.TYPE_DATE).value("2025-09-04").build(),
+                                            GenericProperty.builder().name("periode_declaration_contrat").type(GenericProperty.TYPE_STRING).value("092024062026").build(),
+                                            GenericProperty.builder().name("liste_prenoms").type(GenericProperty.TYPE_STRING).value("DIALLA BAH").build(),
+                                            GenericProperty.builder().name("nom_patronymique").type(GenericProperty.TYPE_STRING).value("KONATE").build(),
+                                            GenericProperty.builder().name("nature_contrat").type(GenericProperty.TYPE_STRING).value("01").build(),
+                                            GenericProperty.builder().name("unauthorized_noise").type(GenericProperty.TYPE_STRING).value("remove_me").build()
+                                    ))
+                                    .build()
+                    ))
+                    .build();
+
+            ResultModel output = sanitizer.sanitize(input, professionalDoc);
+
+            assertThat(output.getBarcodes()).hasSize(1);
+            assertThat(output.getBarcodes().get(0).getRawData()).isNull();
+            assertThat(output.getBarcodes().get(0).getTypedData())
+                    .extracting(GenericProperty::getName)
+                    .containsExactlyInAnyOrder(
+                            "doc_type",
+                            "date_debut_contrat",
+                            "periode_declaration_contrat",
+                            "liste_prenoms",
+                            "nom_patronymique",
+                            "nature_contrat"
+                    );
+        }
+
+        @Test
         void should_remove_raw_data_for_all_barcodes_even_when_typed_data_is_null_or_empty() {
             DocumentIAResultSanitizer sanitizer = newSanitizer(List.of(TestIdentityTwoDDocModel.class));
 


### PR DESCRIPTION
Cette PR met en place le traitement des documents de la catégorie Activité professionnelle (CDI, CDD, ALTERNATION, INTERNSHIP, INTERMITTENT) via Document-IA :

  • Déclenchement & Workflow : Sous le feature-flag document-ia-professional-analysis, ces sous-catégories sont envoyées vers le workflow 2D-Doc document-barcode-extraction-
  v2.
  • Périmètre géré (PNDS) : Seules les attestations d'activité professionnelle comportant un 2D-Doc de type 29 (PNDS) sont actuellement analysées.
  • Gestion du statut de classification : Si le 2D-Doc attendu (type 29) n'est pas détecté, la règle de classification retourne un résultat bloquant et inconclusive
  (ProfessionalClassificationRuleBI), ce qui classe le rapport en UNDEFINED (et non en FAILED). En effet, la catégorie professionnelle accepte d'autres justificatifs
  (contrats, bulletins, etc.) qui ne sont pas encore pris en charge par ce workflow 2D-Doc.

  ### 🧪 Règles exécutées sur le 2D-Doc PNDS :

  1. HasBeenDocumentIAAnalysedBI (Vérification du succès de l'analyse IA)
  2. ProfessionalClassificationRuleBI (Vérification de la présence d'un 2D-Doc type 29)
  3. Professional2DDocIssueDateRule (Vérification que l'attestation a été émise il y a moins de 2 mois)
  4. ProfessionalNamesRule (Vérification du nom et prénom du locataire ou du garant via liste_prenoms et nom_patronymique)
