### PR TITLE
fix(completed-optin): a dossier in the operator queue never leaves it…

### DIFF
--- a/docs/completed-optin.md
+++ b/docs/completed-optin.md
@@ -44,7 +44,15 @@ Périmètre MVP : dossiers **ALONE uniquement**, rollout progressif démarré à
 COMPLETED  ⟺  dossier complet + déclaration sur l'honneur signée
               + éligible (§3.2)
               + validation_requested ≠ true
+              + le dossier ENTRE en file (statut persisté ≠ TO_PROCESS)   — §3.3
 ```
+
+### 3.3 Invariant : un dossier en file n'en sort que sur décision explicite
+L'éligibilité peut changer **après** la soumission (hausse du `rollout_pct` : `ROLLOUT_INCREASED` rebascule d'un coup toutes les assignations `HASH` dont le bucket passe sous le nouveau seuil ; suppression d'une ligne `tenant_userapi` ; dissociation d'une coloc). Sans garde, un dossier `TO_PROCESS` devenu éligible quittait silencieusement la file au premier recalcul de statut — y compris lors d'une action opérateur dans le BO (`deleteFile`, `changeDocumentStatus`…), le verdict échouant ensuite sur le garde-fou `processFile` (incident du 27/08/2026, 3 dossiers).
+
+Règle (`CompletedDossierService.toCompletedIfEligible`) : la surcouche `COMPLETED` ne s'applique qu'à l'**entrée** en `TO_PROCESS`, c'est-à-dire quand le statut **persisté** n'est pas `TO_PROCESS` — soumission (`INCOMPLETE`), re-soumission après refus (`DECLINED` : le remplacement d'une pièce refusée ramène directement en `TO_PROCESS`, sans nouvelle signature) ou après validation (`VALIDATED`). Un dossier déjà `TO_PROCESS` reste `TO_PROCESS` quel que soit le recalcul (édition locataire, édition opérateur, changement d'éligibilité).
+
+Les seules sorties de la file sont donc explicites : le verdict opérateur, et l'annulation de la demande de vérification par le locataire, qui passe par **`CompletedDossierService.switchToCompleted()`** (statut `COMPLETED`, `last_update_date` de l'`apartment_sharing` rafraîchi ; garde : `TO_PROCESS` + `canBeCompleted`). Conséquence pour les paliers de rollout : les dossiers déjà en file au moment du palier y restent et sont traités normalement (*grandfathering*) — aucune action, aucun mail le jour du palier.
 
 ### 3.2 Éligibilité (`CompletedEligibilityService`, common-library)
 Toujours **calculée à la volée, jamais stockée** (elle dépend d'états qui changent à tout moment). Conditions, évaluées de la moins chère à la plus chère :
@@ -97,10 +105,10 @@ Deux méthodes publiques :
 ## 5. Transitions de statut
 
 ### 5.1 Entrée : passage en COMPLETED à la soumission (api-tenant)
-`TenantStatusServiceImpl.updateTenantStatus()` — appelé par tous les `SaveStep`, dont la déclaration sur l'honneur — applique `CompletedDossierService.toCompletedIfEligible()` : si `computeStatus()` retourne `TO_PROCESS` **et** `canBeCompleted(tenant)`, le statut persisté devient `COMPLETED`. `Tenant.computeStatus()` est inchangé. Aucun webhook partenaire n'est émis (un dossier passé en `COMPLETED` n'a par définition aucun partenaire lié).
+`TenantStatusServiceImpl.updateTenantStatus()` — appelé par tous les `SaveStep`, dont la déclaration sur l'honneur — applique `CompletedDossierService.toCompletedIfEligible()` : si `computeStatus()` retourne `TO_PROCESS`, que le statut persisté n'est **pas** déjà `TO_PROCESS` (§3.3) **et** `canBeCompleted(tenant)`, le statut persisté devient `COMPLETED`. `Tenant.computeStatus()` est inchangé. Aucun webhook partenaire n'est émis (un dossier passé en `COMPLETED` n'a par définition aucun partenaire lié).
 
 ### 5.2 Même règle côté BO
-`fr.gouv.bo.service.TenantService.updateTenantStatus()` (re-synchronisation après suppression/modification de document par un opérateur) applique la même règle via `CompletedDossierService.toCompletedIfEligible()` — la logique n'existe qu'à un seul endroit.
+`fr.gouv.bo.service.TenantService.updateTenantStatus()` (re-synchronisation après suppression/modification de document par un opérateur) applique la même règle via `CompletedDossierService.toCompletedIfEligible()` — la logique n'existe qu'à un seul endroit. Grâce à l'invariant §3.3, une action opérateur sur un dossier `TO_PROCESS` ne peut jamais le sortir de la file ; seul un dossier `COMPLETED` consulté par recherche peut être recalculé vers `INCOMPLETE`/`COMPLETED`.
 
 ### 5.3 Agrégat coloc
 `ApartmentSharing.getStatus()` gère `COMPLETED` explicitement (entre `TO_PROCESS` et `VALIDATED`), la structure existante de la méthode restant inchangée. Sans ce cas, un dossier ALONE `COMPLETED` serait tombé dans le `return VALIDATED` final — exposant tokens de partage, full PDF et mails propriétaire « dossier validé ».
@@ -109,6 +117,7 @@ Deux méthodes publiques :
 | Cause | Mécanisme | `validation_requested` |
 |---|---|---|
 | Le locataire demande une vérification | endpoint §6 → `TO_PROCESS`, `last_update_date = now` (position en file = moment du choix) | `true` (son choix) |
+| Le locataire annule sa demande (sens inverse : `TO_PROCESS → COMPLETED`) | endpoint §6 → `switchToCompleted()` (§3.3), seule sortie de file à l'initiative du locataire | `false` (son choix) |
 | Connexion à un partenaire ou candidature propriétaire | bascule automatique §7.1 | inchangé |
 | Rollback | action BO §9 | inchangé |
 | Modification du dossier | `computeStatus()` → `INCOMPLETE`, puis retour possible en `COMPLETED` à la re-signature | inchangé |
@@ -122,7 +131,7 @@ Toute sortie de `COMPLETED` invalide le full PDF (design « non vérifié », §
 
 - **`PUT /api/tenant/validation-request`** (scope `dossier`), body `{"validationRequested": true|false}` :
   - refuse (`409`) si `isEligibleForOptIn` est faux ;
-  - persiste le choix, positionne `last_update_date = now`, journalise (`VALIDATION_REQUESTED` / `VALIDATION_DECLINED`), recalcule le statut ;
+  - persiste le choix, positionne `last_update_date = now`, journalise (`VALIDATION_REQUESTED` / `VALIDATION_DECLINED`), puis recalcule le statut — sauf pour l'annulation d'un dossier `TO_PROCESS`, qui passe par `switchToCompleted()` (§3.3) ;
   - si le dossier passe effectivement `COMPLETED → TO_PROCESS` (réponse « oui »), envoie le **template Brevo 56 existant** (« dossier complet, en attente de vérification ») — même situation qu'une soumission classique, aucun nouveau template ;
   - accepté aussi sur un dossier `VALIDATED` ou `DECLINED` : le recalcul de statut est alors un no-op (`computeStatus()` retourne le même statut), le choix est simplement enregistré pour la prochaine re-soumission.
 - **`TenantModel`** (profil locataire) expose :
@@ -230,7 +239,7 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 | B3 | Partage B1 | ZIP OK ; création lien/mail et lien par défaut **OK** ; page publique au design « dossier complété, non vérifié » (badges info, documents consultables) ; full PDF généré paresseusement au design COMPLETED |
 | B3bis | Lien créé pendant B1 puis sortie de COMPLETED (opt-in « oui » ou liaison partenaire) | Le lien reste actif et la page publique bascule sur le rendu TO_PROCESS ; le full PDF est invalidé (409/417) puis régénéré au design du nouveau statut |
 | B4 | Encart : répondre « oui » | `validation_requested=true`, statut TO_PROCESS, entre en file (position = maintenant), badge « en cours », log `VALIDATION_REQUESTED`, mail template 56 reçu |
-| B5 | B4 puis annuler | Retour `COMPLETED`, `validation_requested=false`, sort de la file |
+| B5 | B4 puis annuler | Retour `COMPLETED`, `validation_requested=false`, sort de la file (`switchToCompleted`) |
 | B6 | B1 → connexion à un partenaire DFC | Bascule immédiate TO_PROCESS, `validation_requested` reste `null`, mail de bascule, webhook `CREATED_ACCOUNT` avec `status=TO_PROCESS` (payload + `callback_log` : jamais COMPLETED), encart disparu, dossier en file |
 | B7 | B1 → candidature propriétaire (`/candidater/:token`) | Même bascule que B6 ; écran de confirmation owner = wording TO_PROCESS standard ; mail owner « candidat non validé », **pas** le « validé » |
 | B8 | B1 → modification d'un document | INCOMPLETE → re-signature → re-COMPLETED (choix inchangé, pas de nouvelle question) |
@@ -239,11 +248,13 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 | B11 | Compte rollout mais connecté DFC avant soumission | Signature → TO_PROCESS direct, mail 56 classique, pas d'encart |
 | B12 | Vérif exposition B1 | Profil : `optInEligible=true`, `validationRequested` absent ; `apartmentSharing.status` ≠ VALIDATED (tokens de partage absents du JSON) |
 | B13 | BO : regroupement impliquant B1 | Bloqué avec message |
+| B14 | Dossier A1 (hors rollout, en file) → passage du rollout à 100 % → suppression d'un fichier par un opérateur dans le BO, ou ajout d'un document par le locataire | Reste `TO_PROCESS` et en file ; le verdict opérateur fonctionne (§3.3). Après refus puis correction : re-soumission directement en `COMPLETED` (B9) |
 
 ### C. Transverses / rollback
 
 | # | Scénario | Attendu |
 |---|---|---|
+| C0 | Rollout 25 → 50 % avec des dossiers ALONE en file | `ROLLOUT_INCREASED` sur les assignations, **aucun changement de statut** : les dossiers en file y restent (§3.3), pas d'encart (affiché seulement pour `COMPLETED` ou demande en cours) |
 | C1 | Rollout 100 → 0 % | Nouvelles soumissions → TO_PROCESS ; dossiers COMPLETED existants **inchangés** tant que l'action de rollback n'est pas lancée |
 | C2 | Action « Rebasculer les dossiers COMPLETED » | Tous → TO_PROCESS, `last_update_date=now` (fin de file), `validation_requested` intact, mail de bascule, logs `COMPLETED_SWITCHED_TO_PROCESS` |
 | C3 | Métriques | Répartition `validation_requested` sur la cohorte assignée ; comptage des logs |

--- a/docs/completed-optin.md
+++ b/docs/completed-optin.md
@@ -48,11 +48,7 @@ COMPLETED  ⟺  dossier complet + déclaration sur l'honneur signée
 ```
 
 ### 3.3 Invariant : un dossier en file n'en sort que sur décision explicite
-L'éligibilité peut changer **après** la soumission (hausse du `rollout_pct` : `ROLLOUT_INCREASED` rebascule d'un coup toutes les assignations `HASH` dont le bucket passe sous le nouveau seuil ; suppression d'une ligne `tenant_userapi` ; dissociation d'une coloc). Sans garde, un dossier `TO_PROCESS` devenu éligible quittait silencieusement la file au premier recalcul de statut — y compris lors d'une action opérateur dans le BO (`deleteFile`, `changeDocumentStatus`…), le verdict échouant ensuite sur le garde-fou `processFile` (incident du 27/08/2026, 3 dossiers).
-
-Règle (`CompletedDossierService.toCompletedIfEligible`) : la surcouche `COMPLETED` ne s'applique qu'à l'**entrée** en `TO_PROCESS`, c'est-à-dire quand le statut **persisté** n'est pas `TO_PROCESS` — soumission (`INCOMPLETE`), re-soumission après refus (`DECLINED` : le remplacement d'une pièce refusée ramène directement en `TO_PROCESS`, sans nouvelle signature) ou après validation (`VALIDATED`). Un dossier déjà `TO_PROCESS` reste `TO_PROCESS` quel que soit le recalcul (édition locataire, édition opérateur, changement d'éligibilité).
-
-Les seules sorties de la file sont donc explicites : le verdict opérateur, et l'annulation de la demande de vérification par le locataire, qui passe par **`CompletedDossierService.switchToCompleted()`** (statut `COMPLETED`, `last_update_date` de l'`apartment_sharing` rafraîchi ; garde : `TO_PROCESS` + `canBeCompleted`). Conséquence pour les paliers de rollout : les dossiers déjà en file au moment du palier y restent et sont traités normalement (*grandfathering*) — aucune action, aucun mail le jour du palier.
+L'éligibilité peut changer **après** la soumission (hausse du `rollout_pct` : `ROLLOUT_INCREASED` rebascule d'un coup toutes les assignations `HASH` dont le bucket passe sous le nouveau seuil ; suppression d'une ligne `tenant_userapi` ; dissociation d'une coloc). Sans garde, un dossier `TO_PROCESS` devenu éligible quittait silencieusement la file au premier recalcul de statut — y compris lors d'une action opérateur dans le BO.
 
 ### 3.2 Éligibilité (`CompletedEligibilityService`, common-library)
 Toujours **calculée à la volée, jamais stockée** (elle dépend d'états qui changent à tout moment). Conditions, évaluées de la moins chère à la plus chère :

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
@@ -26,6 +26,7 @@ import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.LogService;
@@ -67,6 +68,7 @@ public class TenantServiceImpl implements TenantService {
     private final DocumentRepository documentRepository;
     private final TenantMapperForMail tenantMapperForMail;
     private final CompletedEligibilityService completedEligibilityService;
+    private final CompletedDossierService completedDossierService;
     private final TenantStatusService tenantStatusService;
     private final ApartmentSharingCommonService apartmentSharingCommonService;
 
@@ -88,6 +90,7 @@ public class TenantServiceImpl implements TenantService {
                              DocumentRepository documentRepository,
                              TenantMapperForMail tenantMapperForMail,
                              CompletedEligibilityService completedEligibilityService,
+                             CompletedDossierService completedDossierService,
                              @Lazy TenantStatusService tenantStatusService,
                              ApartmentSharingCommonService apartmentSharingCommonService) {
         this.apartmentSharingRepository = apartmentSharingRepository;
@@ -105,6 +108,7 @@ public class TenantServiceImpl implements TenantService {
         this.documentRepository = documentRepository;
         this.tenantMapperForMail = tenantMapperForMail;
         this.completedEligibilityService = completedEligibilityService;
+        this.completedDossierService = completedDossierService;
         this.tenantStatusService = tenantStatusService;
         this.apartmentSharingCommonService = apartmentSharingCommonService;
     }
@@ -298,7 +302,15 @@ public class TenantServiceImpl implements TenantService {
         tenant.setLastUpdateDate(LocalDateTime.now(ZoneId.systemDefault()));
         tenantRepository.save(tenant);
         logService.saveLog(validationRequested ? LogType.VALIDATION_REQUESTED : LogType.VALIDATION_DECLINED, tenant.getId());
-        Tenant updatedTenant = tenantStatusService.updateTenantStatus(tenant);
+        Tenant updatedTenant;
+        if (!validationRequested && previousStatus == TenantFileStatus.TO_PROCESS) {
+            // Leaving the operator queue is never done by the status recomputation:
+            // the opt-out is the explicit switch
+            completedDossierService.switchToCompleted(tenant);
+            updatedTenant = tenant;
+        } else {
+            updatedTenant = tenantStatusService.updateTenantStatus(tenant);
+        }
         if (previousStatus == TenantFileStatus.COMPLETED && updatedTenant.getStatus() != TenantFileStatus.COMPLETED) {
             // The full PDF was rendered with the COMPLETED design: it must not
             // survive the switch out of COMPLETED

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
@@ -21,6 +21,7 @@ import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.enums.TenantType;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.FileStorageService;
@@ -99,6 +100,8 @@ class DfcTenantsControllerIntegrationTest {
     private DfcDocumentService dfcDocumentService;
     @MockitoBean
     private CompletedEligibilityService completedEligibilityService;
+    @MockitoBean
+    private CompletedDossierService completedDossierService;
     @MockitoBean
     private TenantStatusService tenantStatusService;
     @MockitoBean

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
@@ -25,6 +25,7 @@ import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
 import fr.dossierfacile.common.service.interfaces.CompletedEligibilityService;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.LogService;
@@ -80,6 +81,8 @@ class TenantServiceImplTest {
     private CompletedEligibilityService completedEligibilityService;
     @Mock
     private TenantStatusService tenantStatusService;
+    @Mock
+    private CompletedDossierService completedDossierService;
     @Mock
     private ApartmentSharingCommonService apartmentSharingCommonService;
 
@@ -321,6 +324,44 @@ class TenantServiceImplTest {
         assertEquals(Boolean.FALSE, updated.getValidationRequested());
         verify(logService).saveLog(LogType.VALIDATION_DECLINED, tenant.getId());
         verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
+        verifyNoInteractions(mailService);
+    }
+
+    // Withdrawing the request is the only way a dossier leaves the queue on its own:
+    // it goes through the explicit switch, never through the status recomputation
+    @Test
+    void updateValidationRequest_optOutFromQueue_usesExplicitSwitch() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.TO_PROCESS);
+        tenant.setValidationRequested(true);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(completedDossierService.switchToCompleted(tenant)).thenAnswer(invocation -> {
+            tenant.setStatus(TenantFileStatus.COMPLETED);
+            return true;
+        });
+
+        Tenant updated = tenantService.updateValidationRequest(tenant, false);
+
+        assertEquals(TenantFileStatus.COMPLETED, updated.getStatus());
+        assertEquals(Boolean.FALSE, updated.getValidationRequested());
+        verify(logService).saveLog(LogType.VALIDATION_DECLINED, tenant.getId());
+        verify(completedDossierService).switchToCompleted(tenant);
+        verify(tenantStatusService, never()).updateTenantStatus(any());
+        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
+        verifyNoInteractions(mailService);
+    }
+
+    @Test
+    void updateValidationRequest_optInFromQueue_goesThroughStatusRecomputation() {
+        // A TO_PROCESS dossier asking for a verification stays in the queue
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.TO_PROCESS);
+        when(completedEligibilityService.isEligibleForOptIn(tenant)).thenReturn(true);
+        when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
+
+        Tenant updated = tenantService.updateValidationRequest(tenant, true);
+
+        assertEquals(TenantFileStatus.TO_PROCESS, updated.getStatus());
+        verify(tenantStatusService).updateTenantStatus(tenant);
+        verify(completedDossierService, never()).switchToCompleted(any());
         verifyNoInteractions(mailService);
     }
 

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
@@ -31,6 +31,7 @@ public class BOFeatureFlagsController {
         List<FeatureFlag> featureFlags = featureFlagService.getAllFeatureFlags();
         model.addAttribute("featureFlags", featureFlags);
         // The COMPLETED rollback is a full rollback only: allowed once the flag is deactivated or at 0%
+        // TODO remove this block once optin is rolled out to 100% 
         boolean completedRollbackAllowed = featureFlags.stream()
                 .filter(flag -> CompletedEligibilityService.COMPLETED_OPTIN_FEATURE_FLAG.equals(flag.getKey()))
                 .findFirst()
@@ -59,6 +60,7 @@ public class BOFeatureFlagsController {
 
     // Rollback action for the COMPLETED opt-in MVP: sends every COMPLETED dossier back
     // to the operator queue. Meant to be run manually after lowering/deactivating the flag.
+    // TODO(completed-optin-rollout-100): remove together with the flag check (see above)
     @PostMapping("/bo/feature-flags/completed-rollback")
     public String rollbackCompletedDossiers() {
         int count = tenantService.switchCompletedDossiersBackToProcessing();

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/service/TenantService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/service/TenantService.java
@@ -990,6 +990,8 @@ public class TenantService {
 
     // Rollback action for the COMPLETED opt-in MVP: sends every COMPLETED dossier back
     // to the operator queue.
+    // TODO(completed-optin-rollout-100): remove together with the feature flag check
+    //  (CompletedEligibilityServiceImpl) and the BO rollback endpoint
     @Transactional(propagation = Propagation.NEVER)
     public int switchCompletedDossiersBackToProcessing() {
         FeatureFlag featureFlag = featureFlagService.getFeatureFlag(CompletedEligibilityService.COMPLETED_OPTIN_FEATURE_FLAG);

--- a/dossierfacile-bo/src/main/resources/templates/bo/feature-flags.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/feature-flags.html
@@ -103,6 +103,8 @@
                     Rollback total uniquement : le flag <code>tenant_completed_optin</code> doit d'abord être
                     désactivé ou à 0&nbsp;%.
                 </p>
+                <!-- TODO(completed-optin-rollout-100): remove this rollback section together with
+                     BOFeatureFlagsController#rollbackCompletedDossiers -->
                 <p th:unless="${completedRollbackAllowed}" class="alert alert-secondary mb-0">
                     <i class="fa fa-lock"></i>
                     Action indisponible : désactivez le flag <code>tenant_completed_optin</code> ou passez son rollout à 0&nbsp;% pour la débloquer.

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
@@ -1,6 +1,7 @@
 package fr.dossierfacile.common.service;
 
 import fr.dossierfacile.common.dto.mail.TenantDto;
+import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.entity.TenantLog;
 import fr.dossierfacile.common.entity.UserApi;
@@ -38,10 +39,35 @@ public class CompletedDossierServiceImpl implements CompletedDossierService {
 
     @Override
     public TenantFileStatus toCompletedIfEligible(Tenant tenant, TenantFileStatus computedStatus) {
-        if (computedStatus == TenantFileStatus.TO_PROCESS && completedEligibilityService.canBeCompleted(tenant)) {
+        if (computedStatus != TenantFileStatus.TO_PROCESS) {
+            return computedStatus;
+        }
+        // A dossier already waiting in the operator queue stays there: the opt-in
+        // only applies when entering the queue. Without this guard, a dossier that
+        // became eligible after its submission (rollout increase) would silently
+        // leave the queue at the first recomputation, possibly while an operator
+        // is processing it
+        if (tenant.getStatus() == TenantFileStatus.TO_PROCESS) {
+            return computedStatus;
+        }
+        if (completedEligibilityService.canBeCompleted(tenant)) {
             return TenantFileStatus.COMPLETED;
         }
         return computedStatus;
+    }
+
+    @Override
+    @Transactional
+    public boolean switchToCompleted(Tenant tenant) {
+        if (tenant.getStatus() != TenantFileStatus.TO_PROCESS || !completedEligibilityService.canBeCompleted(tenant)) {
+            return false;
+        }
+        tenant.setStatus(TenantFileStatus.COMPLETED);
+        tenantCommonRepository.save(tenant);
+        ApartmentSharing apartmentSharing = tenant.getApartmentSharing();
+        apartmentSharing.setLastUpdateDate(LocalDateTime.now(ZoneId.systemDefault()));
+        apartmentSharingCommonService.save(apartmentSharing);
+        return true;
     }
 
     // A COMPLETED dossier must never be exposed to partners: it goes back to the

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedEligibilityServiceImpl.java
@@ -53,6 +53,8 @@ public class CompletedEligibilityServiceImpl implements CompletedEligibilityServ
         }
         // The feature flag check comes last: its first evaluation persists a bucket
         // assignment for the user, so only real candidates enter the metrics denominator
+        // TODO(completed-optin-rollout-100): remove this check (and the flag) once the rollout
+        //  is stable at 100%.
         return featureFlagService.isFeatureEnabledForUser(tenant.getId(), COMPLETED_OPTIN_FEATURE_FLAG);
     }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/CompletedDossierService.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/CompletedDossierService.java
@@ -12,9 +12,23 @@ public interface CompletedDossierService {
 
     /**
      * Returns COMPLETED instead of TO_PROCESS when the dossier is eligible to the
-     * opt-in. Any other computed status is returned unchanged.
+     * opt-in and is ENTERING the operator queue (its persisted status is not
+     * TO_PROCESS). Any other computed status is returned unchanged.
+     * <p>
+     * Invariant: a dossier already waiting in the queue never leaves it through a
+     * status recomputation (tenant edit, operator edit in the BO, rollout increase
+     * of the feature flag). Leaving the queue is always an explicit decision: the
+     * operator verdict, or the tenant's opt-out via {@link #switchToCompleted}.
      */
     TenantFileStatus toCompletedIfEligible(Tenant tenant, TenantFileStatus computedStatus);
+
+    /**
+     * Explicit opt-out: takes a TO_PROCESS dossier out of the operator queue and
+     * makes it COMPLETED. No-op (returns false) when the dossier is not TO_PROCESS
+     * or not eligible. The caller is responsible for having persisted the user's
+     * choice (validationRequested) beforehand, as eligibility depends on it.
+     */
+    boolean switchToCompleted(Tenant tenant);
 
     /**
      * Sends a COMPLETED dossier back to the operator queue: status TO_PROCESS,

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
@@ -66,19 +66,48 @@ class CompletedDossierServiceImplTest {
     class ToCompletedIfEligible {
 
         @Test
-        void should_switch_to_completed_when_eligible() {
+        void should_switch_to_completed_when_eligible_and_entering_the_queue() {
+            // Given - submission: the persisted status is not TO_PROCESS yet
+            tenant.setStatus(TenantFileStatus.INCOMPLETE);
             when(completedEligibilityService.canBeCompleted(tenant)).thenReturn(true);
 
             assertThat(service.toCompletedIfEligible(tenant, TenantFileStatus.TO_PROCESS))
                     .isEqualTo(TenantFileStatus.COMPLETED);
         }
 
+        // A declined document replaced by the tenant sends the dossier straight back to
+        // TO_PROCESS (no new honor declaration): this is an entry into the queue too
+        @Test
+        void should_switch_to_completed_when_resubmitting_after_a_verdict() {
+            for (TenantFileStatus previous : new TenantFileStatus[]{TenantFileStatus.DECLINED, TenantFileStatus.VALIDATED}) {
+                tenant.setStatus(previous);
+                when(completedEligibilityService.canBeCompleted(tenant)).thenReturn(true);
+
+                assertThat(service.toCompletedIfEligible(tenant, TenantFileStatus.TO_PROCESS))
+                        .as("re-entering the queue from %s", previous)
+                        .isEqualTo(TenantFileStatus.COMPLETED);
+            }
+        }
+
         @Test
         void should_keep_to_process_when_not_eligible() {
+            tenant.setStatus(TenantFileStatus.INCOMPLETE);
             when(completedEligibilityService.canBeCompleted(tenant)).thenReturn(false);
 
             assertThat(service.toCompletedIfEligible(tenant, TenantFileStatus.TO_PROCESS))
                     .isEqualTo(TenantFileStatus.TO_PROCESS);
+        }
+
+        // Regression: a dossier that became eligible after its submission (rollout
+        // increase) must not leave the queue at the first recomputation, e.g. while
+        // an operator deletes a file in the BO
+        @Test
+        void should_never_take_a_dossier_already_in_the_queue_out_of_it() {
+            tenant.setStatus(TenantFileStatus.TO_PROCESS);
+
+            assertThat(service.toCompletedIfEligible(tenant, TenantFileStatus.TO_PROCESS))
+                    .isEqualTo(TenantFileStatus.TO_PROCESS);
+            verifyNoInteractions(completedEligibilityService);
         }
 
         @Test
@@ -88,6 +117,51 @@ class CompletedDossierServiceImplTest {
                 assertThat(service.toCompletedIfEligible(tenant, status)).isEqualTo(status);
             }
             verifyNoInteractions(completedEligibilityService);
+        }
+    }
+
+    @Nested
+    class SwitchToCompleted {
+
+        @Test
+        void should_take_an_eligible_dossier_out_of_the_queue() {
+            // Given - the tenant withdrew its verification request
+            tenant.setStatus(TenantFileStatus.TO_PROCESS);
+            tenant.setValidationRequested(false);
+            when(completedEligibilityService.canBeCompleted(tenant)).thenReturn(true);
+
+            // When
+            boolean switched = service.switchToCompleted(tenant);
+
+            // Then
+            assertThat(switched).isTrue();
+            assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+            verify(tenantCommonRepository).save(tenant);
+            assertThat(apartmentSharing.getLastUpdateDate()).isNotNull();
+            verify(apartmentSharingCommonService).save(apartmentSharing);
+        }
+
+        @Test
+        void should_do_nothing_when_not_eligible() {
+            tenant.setStatus(TenantFileStatus.TO_PROCESS);
+            when(completedEligibilityService.canBeCompleted(tenant)).thenReturn(false);
+
+            assertThat(service.switchToCompleted(tenant)).isFalse();
+            assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.TO_PROCESS);
+            verify(tenantCommonRepository, never()).save(any(Tenant.class));
+        }
+
+        @Test
+        void should_do_nothing_when_dossier_is_not_in_the_queue() {
+            for (TenantFileStatus status : new TenantFileStatus[]{
+                    TenantFileStatus.INCOMPLETE, TenantFileStatus.COMPLETED, TenantFileStatus.VALIDATED, TenantFileStatus.DECLINED}) {
+                tenant.setStatus(status);
+
+                assertThat(service.switchToCompleted(tenant)).as("from %s", status).isFalse();
+                assertThat(tenant.getStatus()).isEqualTo(status);
+            }
+            verifyNoInteractions(completedEligibilityService);
+            verify(tenantCommonRepository, never()).save(any(Tenant.class));
         }
     }
 


### PR DESCRIPTION
… through a status recomputation

The COMPLETED opt-in overlay was applied at every status recomputation. A dossier that became eligible after its submission (rollout increase of the feature flag, 5% -> 25% on 2026-08-27) silently left the TO_PROCESS queue at the first recomputation - including an operator deleting a file in the BO, whose verdict then failed on the processFile guard.

- toCompletedIfEligible only applies when the dossier ENTERS the queue (persisted status != TO_PROCESS): submission, re-submission after a DECLINED or VALIDATED verdict. A TO_PROCESS dossier stays TO_PROCESS.
- Leaving the queue is always explicit: operator verdict, or the tenant's opt-out through the new CompletedDossierService.switchToCompleted().
- Dossiers already queued at a rollout step are grandfathered: nothing to do on the day of the step.