### PR TITLE
feat : display COMPLETED dossier for opted-in partner

### DIFF
--- a/docs/completed-optin.md
+++ b/docs/completed-optin.md
@@ -2,13 +2,13 @@
 
 ## 1. Vue d'ensemble
 
-Le module **Opt-in COMPLETED** introduit un nouveau statut de dossier `COMPLETED` : un dossier complet et soumis (déclaration sur l'honneur signée), **utilisable immédiatement par le locataire sans vérification opérateur**. Le locataire peut le partager par téléchargement ZIP des justificatifs filigranés, ainsi que par lien et par mail (itération « partage COMPLETED » : page publique et full PDF au design « dossier complété, non vérifié », cf. §7.2) ; l'espace propriétaire et DossierFacile Connect restent réservés aux dossiers `VALIDATED`.
+Le module **Opt-in COMPLETED** introduit un nouveau statut de dossier `COMPLETED` : un dossier complet et soumis (déclaration sur l'honneur signée), **utilisable immédiatement par le locataire sans vérification opérateur**. Le locataire peut le partager par téléchargement ZIP des justificatifs filigranés, ainsi que par lien et par mail (page publique et full PDF au design « dossier non vérifié », cf. §7.2). Depuis l'itération « partage en TO_PROCESS », un dossier `TO_PROCESS` se partage exactement comme un `COMPLETED`; les partenaires (DFC, api-partner) voient `COMPLETED` s'ils ont **intégré ce statut** (cf. [partner-completed-optin.md](partner-completed-optin.md)).
 
 Objectif : réduire la charge opérateur en laissant, par défaut, les dossiers éligibles hors de la file de traitement — la vérification devient un choix explicite du locataire.
 
 Ce système garantit :
 - **Un comportement strictement inchangé hors rollout** : la machine à états (`Tenant.computeStatus()`) n'est pas modifiée ; le passage en `COMPLETED` est une surcouche conditionnée par un feature flag.
-- **L'invisibilité totale du statut pour les partenaires** (DFC, api-partner, espace propriétaire) via trois verrous complémentaires (§7).
+- **L'invisibilité du statut pour les partenaires n'ayant pas intégré le statut COMPLETED** (DFC, api-partner) et pour l'espace propriétaire, via trois verrous complémentaires (§7) ; les partenaires ayant intégré `COMPLETED` le voient (cf. [partner-completed-optin.md](partner-completed-optin.md)).
 - **Un seul fait persisté : le choix explicite de l'utilisateur** (`validation_requested`) — l'éligibilité est toujours recalculée, jamais stockée.
 - **Un rollback maîtrisé** : action BO explicite qui rebascule tous les dossiers `COMPLETED` en file de traitement.
 
@@ -52,7 +52,7 @@ Toujours **calculé à la volée, jamais stocké** (dépend d'états qui changen
 
 Condition dans l'ordre :
 1. `application_type = ALONE` ;
-2. **aucune** ligne `tenant_userapi` — règle stricte : tout lien partenaire (DFC ou propriétaire via `dfconnect-proprietaire`), même résiduel après suppression de la candidature, désactive l'opt-in ;
+2. **tous** les liens `tenant_userapi` pointent vers un partenaire ayant intégré `COMPLETED`;
 3. **en dernier** : `FeatureFlagService.isFeatureEnabledForUser(tenantId, "tenant_completed_optin")` — la première évaluation persiste l'assignation de bucket du user ; en le plaçant en dernier, seuls les candidats réels entrent dans le dénominateur des métriques, et les candidats hors rollout (`enabled = false`) forment le groupe contrôle.
 
 Quatre méthodes publiques :
@@ -102,7 +102,7 @@ Quatre méthodes publiques :
 ## 5. Transitions de statut
 
 ### 5.1 Entrée : passage en COMPLETED à la soumission (api-tenant)
-`TenantStatusServiceImpl.updateTenantStatus()` — appelé par tous les `SaveStep`, dont la déclaration sur l'honneur — applique `OperatorReviewPolicy.resolveStatus(tenant, computeStatus())` : un `TO_PROCESS` calculé est persisté en `COMPLETED` ou `TO_PROCESS` selon la policy. `Tenant.computeStatus()` est inchangé. Aucun webhook partenaire n'est émis (un dossier passé en `COMPLETED` n'a par définition aucun partenaire lié).
+`TenantStatusServiceImpl.updateTenantStatus()` — appelé par tous les `SaveStep`, dont la déclaration sur l'honneur — applique `OperatorReviewPolicy.resolveStatus(tenant, computeStatus())` : un `TO_PROCESS` calculé est persisté en `COMPLETED` ou `TO_PROCESS` selon la policy. `Tenant.computeStatus()` est inchangé. À la soumission en `COMPLETED` (depuis `INCOMPLETE`), le webhook **`COMPLETED_ACCOUNT`** est émis à tous les partenaires liés — tous ayant intégré `COMPLETED` par construction, sinon le dossier serait `TO_PROCESS`. Les passages `COMPLETED → TO_PROCESS` et `TO_PROCESS → COMPLETED` n'émettent aucun webhook (cf. partner-completed-optin.md §5).
 
 ### 5.2 Même règle côté BO
 `fr.gouv.bo.service.TenantService.updateTenantStatus()` (re-synchronisation après suppression/modification de document par un opérateur) applique la même règle via `OperatorReviewPolicy.resolveStatus()` — la logique n'existe qu'à un seul endroit.
@@ -115,12 +115,12 @@ Quatre méthodes publiques :
 |---|---|---|
 | Le locataire demande une vérification | endpoint §6 → `TO_PROCESS`, `last_update_date = now` (position en file = moment du choix) | `true` (son choix) |
 | Le locataire annule sa demande (sens inverse : `TO_PROCESS → COMPLETED`) | endpoint §6 → `switchToCompleted()` (§3.3), seule sortie de file à l'initiative du locataire | `false` (son choix) |
-| Connexion à un partenaire ou candidature propriétaire | bascule automatique §7.1 | inchangé |
+| Connexion à un partenaire **n'ayant pas intégré COMPLETED**, ou candidature propriétaire | bascule automatique §7.1 | inchangé |
 | Rollback | action BO §9 | inchangé |
 | Modification du dossier | `computeStatus()` → `INCOMPLETE`, puis retour possible en `COMPLETED` à la re-signature | inchangé |
 | Changement de type ALONE → COUPLE/GROUP | purge + recalcul (§8) | remis à `null` |
 
-Toute sortie de `COMPLETED` invalide le full PDF (design « non vérifié », §7.2) via `resetDossierPdfGenerated` ; les liens de partage existants survivent.
+Les liens de partage existants survivent à toute sortie de `COMPLETED`. Le full PDF aussi : `TO_PROCESS` et `COMPLETED` partagent le même design « non vérifié » (§7.2). Le full PDF n'est invalidé qu'à l'entrée en `VALIDATED` (`TenantCommonServiceImpl.changeTenantStatusToValidated`), où il est régénéré paresseusement au design historique.
 
 ---
 
@@ -140,21 +140,21 @@ Toute sortie de `COMPLETED` invalide le full PDF (design « non vérifié », §
 
 ## 7. Invisibilité partenaires — les trois verrous
 
-Un dossier `COMPLETED` ne doit jamais être vu d'un partenaire (DFC, api-partner) ni d'un propriétaire. Trois mécanismes complémentaires (§7.1, §7.3, §7.4) — le §7.2 décrit le régime des liens de partage, qui ne créent aucun lien partenaire :
+Un dossier `COMPLETED` ne doit jamais être vu d'un partenaire **n'ayant pas intégré ce statut** (DFC, api-partner) ni d'un propriétaire. Les partenaires ayant intégré `COMPLETED` (listés dans le flag `partner_completed_optin`, cf. [partner-completed-optin.md](partner-completed-optin.md)) le voient : les trois verrous ci-dessous sont conditionnés à `OperatorReviewPolicy.isPartnerOptedIn(userApi)`. Le §7.2 décrit le régime des liens de partage, qui ne créent aucun lien partenaire :
 
 ### 7.1 Bascule automatique à la liaison partenaire
-`PartnerCallBackServiceImpl.registerTenant()` — point de passage unique de toute création de lien `tenant_userapi` (connexion DFC, candidature propriétaire via `dfconnect-proprietaire`, propagation aux colocataires) — délègue à **`CompletedDossierService.switchBackToProcessing()`** (logique de bascule unique, partagée avec le rollback) : si le tenant est `COMPLETED`, il repasse `TO_PROCESS` **avant** l'envoi du callback (le webhook `CREATED_ACCOUNT` part donc avec un statut connu des partenaires), avec `last_update_date = now`, log `COMPLETED_SWITCHED_TO_PROCESS` et mail au locataire (template `brevo.template.id.completed.switched.to.processing`) après commit.
+`PartnerCallBackServiceImpl.registerTenant()` — point de passage unique de toute création de lien `tenant_userapi` (connexion DFC, candidature propriétaire via `dfconnect-proprietaire`, propagation aux colocataires) — délègue, **si le partenaire n'a pas intégré le statut COMPLETED**, à **`CompletedDossierService.switchBackToProcessing()`** (logique de bascule unique, partagée avec le rollback) : si le tenant est `COMPLETED`, il repasse `TO_PROCESS` **avant** l'envoi du callback (le webhook `CREATED_ACCOUNT` part donc avec un statut connu du partenaire), avec `last_update_date = now`, log `COMPLETED_SWITCHED_TO_PROCESS` et mail au locataire (template `brevo.template.id.completed.switched.to.processing`) après commit. Pour un partenaire ayant intégré `COMPLETED`, pas de bascule : le webhook `COMPLETED_ACCOUNT` part avec `status = COMPLETED`.
 
-### 7.2 Liens de partage & full PDF (itération « partage COMPLETED »)
-Le partage par lien/mail est ouvert aux dossiers `VALIDATED` **et** `COMPLETED` (`TenantFileStatus.isCompletedOrValidated()`, contrôlé par `TenantServiceImpl.requireCompletedOrValidatedDossier()` et `ApartmentSharingLinkController`, `409` sinon). Les liens LINK/MAIL peuvent donc coexister avec un dossier `COMPLETED` ; ils ne créent aucune ligne `tenant_userapi` et n'entament pas l'invisibilité partenaires. La page publique d'un dossier `COMPLETED` affiche un design « dossier complété, non vérifié par un agent » distinct du rendu `VALIDATED`. Le full PDF `COMPLETED` est un rendu neutre : uniquement les pages de justificatifs (pas de page de garde ni de « mot du locataire ») et sans les logos République Française / DossierFacile dans l'en-tête des pages ; le full PDF `VALIDATED` reste le rendu historique inchangé. La génération du full PDF exige un dossier `VALIDATED` ou `COMPLETED` avec tous les watermarks présents (`countTenantsBlockingFullPdfGeneration`, `417` sinon). À toute sortie de `COMPLETED` (opt-in « oui » §6, bascule partenaire §7.1, rollback §9), les liens **survivent** (la page publique bascule sur le rendu du nouveau statut) mais le full PDF est **invalidé** (`resetDossierPdfGenerated`) — il sera régénéré paresseusement au design du statut courant ; `complete()` (pdf-generator) jette par ailleurs tout fichier généré pendant une invalidation concurrente. Le ZIP (`GET /api/application/zip`) reste accessible quel que soit le statut.
+### 7.2 Liens de partage & full PDF (itérations « partage COMPLETED » + « partage en TO_PROCESS »)
+Le partage par lien/mail est ouvert à tout dossier **soumis** : `TO_PROCESS`, `COMPLETED` ou `VALIDATED` (`TenantFileStatus.isCompletedOrBetter()`, contrôlé par `TenantServiceImpl.requireShareableDossier()` et `ApartmentSharingLinkController`, `409` sinon). Les liens LINK/MAIL ne créent aucune ligne `tenant_userapi` et n'entament pas l'invisibilité partenaires. Un dossier **non vérifié** (`TO_PROCESS` ou `COMPLETED`) a un rendu unique, distinct du rendu `VALIDATED` : page publique « dossier complet, non vérifié par un agent », badges de documents « Document déposé », total des revenus masqué ; full PDF neutre — uniquement les pages de justificatifs (pas de page de garde ni de « mot du locataire ») et sans les logos République Française / DossierFacile dans l'en-tête (`ApartmentSharingPdfDocumentTemplate`, `unverifiedDossier = status != VALIDATED`) ; le full PDF `VALIDATED` reste le rendu historique inchangé. La génération du full PDF exige un dossier soumis avec tous les watermarks présents (`countTenantsBlockingFullPdfGeneration`, `417` sinon). `TO_PROCESS` et `COMPLETED` étant équivalents, aucune sortie de `COMPLETED` n'invalide le full PDF ; il n'est invalidé qu'à l'entrée en `VALIDATED` (`changeTenantStatusToValidated`), et `complete()` (pdf-generator) jette tout fichier généré pendant une invalidation concurrente. Le ZIP (`GET /api/application/zip`) reste accessible quel que soit le statut.
 
 ### 7.3 Filet défensif dans les mappers
-`PartnerVisibleStatus.mask(status, source)` (common-library) : convertit `COMPLETED → TO_PROCESS` et émet un **`log.error`** — « *Defensive status masking triggered in {source}…* ». Ce cas ne doit jamais se produire : toute occurrence dans ELK signale un invariant cassé, à investiguer (les dossiers concernés se retrouvent via `status = 'COMPLETED' AND EXISTS tenant_userapi`). Branché dans six mappers :
-- conditionnel au contexte partenaire (`userApi != null`) là où le mapper sert aussi le locataire : `ApplicationFullMapper` (webhooks, api-partner), `TenantMapper` (profil + DFC) ;
+`PartnerVisibleStatus.mask(status, source)` (common-library) : convertit `COMPLETED → TO_PROCESS` et émet un **`log.error`** — « *Defensive status masking triggered in {source}…* ». Ce cas ne doit jamais se produire : toute occurrence dans ELK signale un invariant cassé, à investiguer (les dossiers concernés se retrouvent via la requête de partner-completed-optin.md §8). Branché dans six mappers :
+- conditionnel au contexte d'un partenaire **n'ayant pas intégré COMPLETED** (`userApi != null && !isPartnerOptedIn(userApi)`, classe de base `MasksCompletedStatusForPartner`) là où le mapper sert aussi le locataire : `ApplicationFullMapper` (webhooks, api-partner), `TenantMapper` (profil + DFC) — ce dernier cache aussi `optInEligible` et `validationRequested` en contexte partenaire ;
 - inconditionnel dans le module api-owner, dont tous les lecteurs sont externes : `PropertyMapper`, `OwnerPropertyMapper`, `ApartmentSharingModelMapper`, `OwnerMapper`.
 
-### 7.4 Règle d'éligibilité stricte
-Toute ligne `tenant_userapi`, même résiduelle, rend le dossier inéligible (§3.2) : un dossier lié à un partenaire ne peut pas *devenir* `COMPLETED`, la bascule 7.1 garantissant qu'il ne peut pas le *rester*.
+### 7.4 Règle d'éligibilité
+Toute ligne `tenant_userapi` vers un partenaire n'ayant pas intégré COMPLETED, même résiduelle, rend le dossier inéligible (§3.2) : un dossier lié à un tel partenaire ne peut pas *devenir* `COMPLETED`, la bascule 7.1 garantissant qu'il ne peut pas le *rester*.
 
 ---
 
@@ -201,7 +201,7 @@ Le branchement du mail de soumission se fait sur le **statut résultant** (dans 
 - Nouveaux `LogType` dans `tenant_log` : `VALIDATION_REQUESTED`, `VALIDATION_DECLINED` (choix utilisateur), `COMPLETED_SWITCHED_TO_PROCESS` (toute bascule automatique ou rollback).
 - Métriques du MVP par simple SQL : répartition de `validation_requested` (`null` = jamais répondu / `false` = complété par défaut ou décliné / `true` = vérification demandée) sur la cohorte assignée (`user_feature_assignment`, flag `tenant_completed_optin`), croisée avec les logs.
 - Point de surveillance ELK post-activation : le message « `Defensive status masking triggered` » (§7.3) — zéro occurrence attendue.
-- `callback_log.tenant_status` ne doit jamais contenir `COMPLETED`.
+- `callback_log.tenant_status` ne contient `COMPLETED` que pour des `partner_id` de partenaires ayant intégré `COMPLETED` (requête dans partner-completed-optin.md §8).
 
 ## 12. Non-impacts vérifiés
 
@@ -222,9 +222,9 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 |---|---|---|
 | A1 | Funnel ALONE complet → signature déclaration sur l'honneur | Statut `TO_PROCESS`, mail template 56, badge « en cours de traitement », **pas d'encart** opt-in |
 | A2 | Dossier A1 dans le BO | Présent dans la file (`ranked_tenant`), compteurs inchangés, traitable (validation → VALIDATED + mail ; refus → DECLINED + mail) |
-| A3 | Partage pendant TO_PROCESS | `/partages` sans formulaire ; bloc « documents non vérifiés » + ZIP OK ; après VALIDATED : création lien/mail OK |
+| A3 | Partage pendant TO_PROCESS | `/partages` avec formulaire : création lien/mail OK ; tableau de bord : callout « en cours de traitement » + section de partage (badge « Dossier complet », « non vérifié par un agent ») ; page publique et full PDF au rendu « non vérifié », identiques à B3 |
 | A4 | COUPLE : signature | Les deux passent TO_PROCESS, mail au signataire seul (comportement actuel), pas d'encart |
-| A5 | Compte créé via partenaire DFC → funnel → signature | TO_PROCESS, webhook `CREATED_ACCOUNT`, pas d'encart |
+| A5 | Compte créé via partenaire DFC **n'ayant pas intégré COMPLETED** → funnel → signature | TO_PROCESS, webhook `CREATED_ACCOUNT`, pas d'encart (partenaire ayant intégré COMPLETED : voir partner-completed-optin.md §7) |
 | A6 | Vérif SQL `user_feature_assignment` | Le user A1 (candidat réel) est assigné `enabled=false` (groupe contrôle) ; les users A4/A5 ne sont **pas** assignés (conditions 1-2 échouent avant le flag) |
 
 ### B. Dans le rollout (rollout 100 % en préprod)
@@ -234,15 +234,15 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 | B1 | Funnel ALONE complet → signature | Statut `COMPLETED`, badge « Complété », mail template 173, encart affiché sans réponse (`validation_requested = null`) |
 | B2 | Dossier B1 côté BO | Absent de la file et des compteurs ; trouvable par recherche directe, libellé « complété » ; `processFile` impossible |
 | B3 | Partage B1 | ZIP OK ; création lien/mail et lien par défaut **OK** ; page publique au design « dossier complété, non vérifié » (badges info, documents consultables) ; full PDF généré paresseusement au design COMPLETED |
-| B3bis | Lien créé pendant B1 puis sortie de COMPLETED (opt-in « oui » ou liaison partenaire) | Le lien reste actif et la page publique bascule sur le rendu TO_PROCESS ; le full PDF est invalidé (409/417) puis régénéré au design du nouveau statut |
+| B3bis | Lien créé pendant B1 puis sortie de COMPLETED (opt-in « oui » ou liaison partenaire n'ayant pas intégré COMPLETED) | Le lien reste actif, la page publique et le full PDF sont **inchangés** (même rendu « non vérifié » en TO_PROCESS) ; après validation opérateur : rendu « vérifié », full PDF régénéré (409/417 pendant la régénération) |
 | B4 | Encart : répondre « oui » | `validation_requested=true`, statut TO_PROCESS, entre en file (position = maintenant), badge « en cours », log `VALIDATION_REQUESTED`, mail template 56 reçu |
 | B5 | B4 puis annuler | Retour `COMPLETED`, `validation_requested=false`, sort de la file (`switchToCompleted`) |
-| B6 | B1 → connexion à un partenaire DFC | Bascule immédiate TO_PROCESS, `validation_requested` reste `null`, mail de bascule, webhook `CREATED_ACCOUNT` avec `status=TO_PROCESS` (payload + `callback_log` : jamais COMPLETED), encart disparu, dossier en file |
+| B6 | B1 → connexion à un partenaire DFC **n'ayant pas intégré COMPLETED** | Bascule immédiate TO_PROCESS, `validation_requested` reste `null`, mail de bascule, webhook `CREATED_ACCOUNT` avec `status=TO_PROCESS` (payload + `callback_log` : jamais COMPLETED), encart disparu, dossier en file. Partenaire ayant intégré COMPLETED : pas de bascule, `COMPLETED_ACCOUNT` avec `status=COMPLETED` (partner-completed-optin.md §7) |
 | B7 | B1 → candidature propriétaire (`/candidater/:token`) | Même bascule que B6 ; écran de confirmation owner = wording TO_PROCESS standard ; mail owner « candidat non validé », **pas** le « validé » |
 | B8 | B1 → modification d'un document | INCOMPLETE → re-signature → re-COMPLETED (choix inchangé, pas de nouvelle question) |
 | B9 | B4 → validé par un opérateur → modification d'un document | Le choix `validation_requested=true` de B4 persiste → re-soumission en TO_PROCESS, **encart présent** (« annuler ma demande ») ; l'annulation bascule le dossier en COMPLETED. Un dossier examiné (validé ou refusé) dont le choix est `null`/`false` re-soumet **directement en COMPLETED** |
 | B10 | B1 → ajout d'un conjoint (ALONE → COUPLE) | `validation_requested` purgé, dossier INCOMPLETE ; après signature des deux → TO_PROCESS (plus ALONE), pas d'encart |
-| B11 | Compte rollout mais connecté DFC avant soumission | Signature → TO_PROCESS direct, mail 56 classique, pas d'encart |
+| B11 | Compte rollout mais connecté avant soumission à un partenaire DFC **n'ayant pas intégré COMPLETED** | Signature → TO_PROCESS direct, mail 56 classique, pas d'encart |
 | B12 | Vérif exposition B1 | Profil : `optInEligible=true`, `validationRequested` absent ; `apartmentSharing.status` ≠ VALIDATED (tokens de partage absents du JSON) |
 | B13 | BO : regroupement impliquant B1 | Bloqué avec message |
 | B14 | Dossier A1 (hors rollout, en file) → passage du rollout à 100 % → suppression d'un fichier par un opérateur dans le BO, ou ajout d'un document par le locataire | Reste `TO_PROCESS` et en file ; le verdict opérateur fonctionne (§3.3). Après refus puis correction : re-soumission directement en `COMPLETED` (B9) |
@@ -255,7 +255,7 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 | C1 | Rollout 100 → 0 % | Nouvelles soumissions → TO_PROCESS ; dossiers COMPLETED existants **inchangés** tant que l'action de rollback n'est pas lancée |
 | C2 | Action « Rebasculer les dossiers COMPLETED » | Tous → TO_PROCESS, `last_update_date=now` (fin de file), `validation_requested` intact, mail de bascule, logs `COMPLETED_SWITCHED_TO_PROCESS` |
 | C3 | Métriques | Répartition `validation_requested` sur la cohorte assignée ; comptage des logs |
-| C4 | Partenaires | `callback_log.tenant_status` : aucune ligne COMPLETED ; API DFC/api-partner : jamais COMPLETED dans les payloads |
+| C4 | Partenaires | `callback_log.tenant_status = COMPLETED` uniquement pour des `partner_id` de partenaires ayant intégré COMPLETED ; API DFC/api-partner : jamais COMPLETED dans les payloads d'un partenaire n'ayant pas intégré COMPLETED |
 | C5 | ELK | Aucune occurrence de « Defensive status masking triggered » |
 
 ---
@@ -263,7 +263,8 @@ Préparation : flag activé en préprod, `rollout_pct` à 100 % (cohorte test) o
 ## 14. Limites du MVP & évolutions envisagées
 
 - **Colocs/couples exclus** (76-77 % du volume est ALONE) : l'extension passera par l'agrégat `ApartmentSharing.getStatus()` déjà en place (« pire statut gagne » : un seul tenant sans opt-in maintient le dossier global en `TO_PROCESS`).
-- ~~**Partage ZIP uniquement**~~ : levé par l'itération « partage COMPLETED » (§7.2) — liens LINK/MAIL, page publique et full PDF au design dédié.
+- ~~**Partage ZIP uniquement**~~ : levé par l'itération « partage COMPLETED » (§7.2) — liens LINK/MAIL, page publique et full PDF au design dédié ; puis étendu aux dossiers `TO_PROCESS` (itération « partage en TO_PROCESS »).
+- ~~**Invisibilité totale pour les partenaires**~~ : levée partenaire par partenaire par le module [partner-completed-optin.md](partner-completed-optin.md) (flag `partner_completed_optin`, webhook `COMPLETED_ACCOUNT`).
 - ~~**Plafond journalier**~~ : réalisé par le module tirage au sort ([tenant-lottery.md](tenant-lottery.md)) — quand le flag `tenant_lottery` est actif, l'opt-in « oui » enregistre une candidature au tirage quotidien au lieu d'entrer directement en file, et `validation_requested` devient purement déclaratif dans la formule du statut (remplacé par « ticket `DRAWN` »).
 - **Upgrade auto-validation** : laisser le bot Visale valider silencieusement les dossiers `COMPLETED` éligibles (coût opérateur nul, bénéfice usager).
 - Le **frontend** (badge, bloc ZIP, encart de choix — monorepo Dossier-Facile-Frontend) fait l'objet d'une PR séparée consommant `optInEligible` / `validationRequested` / `POST /api/tenant/validation-request`.

--- a/docs/partner-completed-optin.md
+++ b/docs/partner-completed-optin.md
@@ -1,0 +1,133 @@
+# Ouverture du statut COMPLETED aux partenaires l'ayant intégré (flag `partner_completed_optin`)
+
+## 1. Vue d'ensemble
+
+Le statut `COMPLETED` (cf. [completed-optin.md](completed-optin.md)) était invisible des partenaires : toute liaison partenaire renvoyait le dossier en file opérateur (`TO_PROCESS`), donc **toute liaison partenaire était un bypass du tirage au sort** ([tenant-lottery.md](tenant-lottery.md)) et un coût opérateur non plafonné.
+
+Ce module ouvre `COMPLETED` **partenaire par partenaire** : un partenaire **ayant intégré le statut `COMPLETED`** voit le statut `COMPLETED` dans ses payloads, reçoit le webhook `COMPLETED_ACCOUNT`, et la liaison d'un dossier `COMPLETED` à ce partenaire ne le renvoie plus en file.
+
+Garanties :
+- **Flag inactif = comportement antérieur exact** : aucun partenaire n'a intégré `COMPLETED`, les trois verrous de l'opt-in (completed-optin.md §7) s'appliquent à tous.
+- Le partenaire n'est **pas notifié** du passage `COMPLETED → TO_PROCESS`. : depuis l'itération « partage en TO_PROCESS », les deux statuts sont des dossiers *non vérifiés* au rendu identique (page publique, full PDF, URLs). Le partenaire n'a donc **pas** à être notifié du passage `COMPLETED → TO_PROCESS`.
+- **Un partenaire n'ayant pas intégré `COMPLETED` ne le voit jamais** : verrous conditionnels + filets défensifs (§4).
+- **L'espace propriétaire (`dfconnect-proprietaire`) n'est pas considéré comme ayant intégré `COMPLETED`** (garde-fou en lecture et en saisie).
+- **Pas de rollback par partenaire** dans cette version (§9).
+
+Vocabulaire : un partenaire **ayant intégré le statut COMPLETED** (*partner opted in* dans le code) est un partenaire listé dans le flag actif `partner_completed_optin`. Les méthodes en découlent : `FeatureFlagService.isPartnerOptedIn(key, userApi)`, `OperatorReviewPolicy.isPartnerOptedIn(userApi)`.
+
+---
+
+## 2. Modèle de données
+
+Migration : `20260910000000-add-partner-completed-optin-flag.xml`.
+
+- **`feature_flag.opted_in_partners`** (`TEXT`, nullable) : liste de **client ids Keycloak** des partenaires (`dfconnect-xxx`, stockés dans `user_api.name`, champ « clientId » de la fiche partenaire BO ; `name2` est le libellé d'affichage) séparés par des virgules. Null ou vide = aucun partenaire. Parsing dans l'entité (`FeatureFlag.getOptedInPartnerNames()` : trim, doublons et vides ignorés, ordre conservé).
+- **Flag `partner_completed_optin`**, inséré inactif, `only_for_new_user = false`, `rollout_pct = 100` : flag **global** (comme `tenant_lottery`), `rollout_pct` / `only_for_new_user` ignorés.
+
+
+---
+
+## 3. Pilotage BO
+
+Écran `/bo/feature-flags` (rôle ADMIN) :
+- le flag est marqué **Global** (pas de rollout) et affiche ses **partenaires opt-in** en badges ;
+- bouton **« Partenaires »** → modale avec la liste éditable (`user_api.name`, séparés par des virgules) et la liste des partenaires connus en aide à la saisie ;
+- `POST /bo/feature-flags/opted-in-partners` (`key`, `value`) : refuse une clé qui n'est pas un flag partenaire, refuse `dfconnect-proprietaire`, refuse toute liste contenant un nom inconnu (`user_api.name`) — **rien n'est enregistré** dans ces cas, message d'erreur listant les noms inconnus ; succès → message de confirmation, `log.info` ancien → nouveau.
+
+Procédure d'ouverture d'un partenaire : recette de son intégration en préprod (§7), ajout à la liste, puis activation du flag s'il ne l'est pas encore. **Retirer un nom n'agit que sur les nouvelles soumissions et liaisons** (§9).
+
+---
+
+## 4. Verrous conditionnels
+
+Point d'entrée unique : `OperatorReviewPolicy.isPartnerOptedIn(userApi)` → `FeatureFlagService.isPartnerOptedIn("partner_completed_optin", userApi)` (faux si `userApi` nul, nom blanc ou `dfconnect-proprietaire` ; sinon flag actif **et** nom listé, comparaison exacte après trim).
+
+| Verrou (completed-optin.md §7) | Avant | Après |
+|---|---|---|
+| Éligibilité (`OperatorReviewPolicyImpl.supportsCompletedStatus`, règle 2) | aucune ligne `tenant_userapi` | **tous** les liens `tenant_userapi` (`findAllByTenant`) pointent vers un partenaire ayant intégré COMPLETED ; un seul partenaire n'ayant pas intégré COMPLETED force `TO_PROCESS`. Le flag opt-in locataire reste évalué en dernier (assignation de bucket) |
+| Bascule à la liaison (`PartnerCallBackServiceImpl.registerTenant`) | toujours `switchBackToProcessing` | seulement si le partenaire n'a pas intégré `COMPLETED` |
+| Masque (`MasksCompletedStatusForPartner`, classe de base de `ApplicationFullMapper` et `TenantMapper`) | masque si `userApi != null` | masque si `userApi != null` **et** partenaire n'ayant pas intégré COMPLETED ; le statut est testé avant le flag (une lecture du flag seulement pour un `COMPLETED`). `TenantMapper` cache aussi `optInEligible` / `validationRequested` en contexte partenaire |
+| Filet webhook (`PartnerCallBackServiceImpl.getWebhookDTO`) | — | `COMPLETED_ACCOUNT` vers un partenaire n'ayant pas intégré COMPLETED → `CREATED_ACCOUNT` + `log.error` « *Defensive callback type downgrade* » |
+
+Les mappers propriétaires (`MasksCompletedStatusForOwner`, api-owner) restent inconditionnels.
+
+`DfcTenantController.profilePartner` recharge le tenant après la liaison avant de le mapper : la liaison peut avoir basculé le dossier, et le graphe chargé avant elle était périmé (cause de l'unique déclenchement du masque observé en prod, 10/09/2026).
+
+---
+
+## 5. Webhooks
+
+Règle du contrat : **à chaque entrée dans un état, un événement nommé d'après cet état, avec le payload complet** : `CREATED_ACCOUNT` (`TO_PROCESS`), **`COMPLETED_ACCOUNT`** (`COMPLETED`, nouveau), `VERIFIED_ACCOUNT` (`VALIDATED`), `DENIED_ACCOUNT` (`DECLINED`). `PartnerCallBackType.forTenantStatus(status)` porte cette règle pour les renvois (liaison, BO, scheduler).
+
+| Transition | Déclencheur | Avant | Partenaire n'ayant pas intégré COMPLETED | Partenaire ayant intégré COMPLETED |
+|---|---|---|---|---|
+| `INCOMPLETE → TO_PROCESS` | Signature (hors périmètre opt-in, ou lié à un partenaire n'ayant pas intégré COMPLETED) | `CREATED_ACCOUNT` | `CREATED_ACCOUNT` | `CREATED_ACCOUNT` |
+| `INCOMPLETE → COMPLETED` | Signature, dossier dans le périmètre | impossible | impossible | **`COMPLETED_ACCOUNT`** |
+| `TO_PROCESS → COMPLETED` | Le locataire retire sa demande de vérification | impossible | impossible | **`COMPLETED_ACCOUNT`** |
+| `COMPLETED → TO_PROCESS` | Opt-in « oui » hors loterie, ticket tiré, liaison à un partenaire n'ayant pas intégré COMPLETED, rollback | impossible | `CREATED_ACCOUNT` au partenaire qui se lie (comme avant) | **aucun** |
+| Liaison d'un dossier `COMPLETED` | `registerTenant` | bascule puis `CREATED_ACCOUNT` | bascule puis `CREATED_ACCOUNT` | pas de bascule, **`COMPLETED_ACCOUNT`** |
+| Liaison d'un dossier `TO_PROCESS` / `VALIDATED` | `registerTenant` | `CREATED_ACCOUNT` / `VERIFIED_ACCOUNT` | inchangé | inchangé |
+| `COMPLETED → INCOMPLETE` | Suppression d'un document | — | — | aucun (comme `TO_PROCESS → INCOMPLETE`) |
+| Renvoi manuel BO, scheduler PDF en échec | `BOTenantController`, `DocumentTask` | `CREATED_ACCOUNT` / `VERIFIED_ACCOUNT` | inchangé (filet : jamais `COMPLETED_ACCOUNT`) | **`COMPLETED_ACCOUNT`** si `COMPLETED` |
+
+Émetteurs : `TenantStatusServiceImpl.updateTenantStatus` (entrée en `COMPLETED` depuis `INCOMPLETE` ou `TO_PROCESS` ; **rien** sur `COMPLETED → TO_PROCESS`, ni sur `VALIDATED/DECLINED → TO_PROCESS`, comportement historique), `PartnerCallBackServiceImpl.sendCallbackIfEligible` (liaison, tout statut soumis). `CompletedDossierService.switchBackToProcessing` et le tirage n'émettent rien.
+
+---
+
+## 6. Payload
+
+- `status` (niveau dossier et niveau locataire) vaut `COMPLETED` pour un partenaire ayant intégré COMPLETED. `callback_log.tenant_status` le contient donc pour ces partenaires.
+- `dossierUrl` / `dossierPdfUrl` sont renseignés dès qu'un dossier est **soumis** (`TO_PROCESS`, `COMPLETED`, `VALIDATED`) pour tout partenaire disposant d'un lien `PARTNER` full data — itération « partage en TO_PROCESS », indépendante de l'opt-in.
+- Jamais exposés à un partenaire : `optInEligible` (`false`), `validationRequested` (absent), `lotteryStatus`, `nextEligibleDate`.
+- Hors `status` et ces champs, le contenu est identique entre `TO_PROCESS` et `COMPLETED`.
+
+### Note contrat API (à transmettre aux partenaires avant ouverture)
+
+> Nouvelle valeur `COMPLETED` de `status` (dossier et locataire) : dossier complet, soumis, **non vérifié par un agent** ; documents, liens et full PDF exploitables comme en `TO_PROCESS`. Nouveau `partnerCallBackType` **`COMPLETED_ACCOUNT`**, émis à chaque entrée en `COMPLETED` ; il peut être le **premier** événement reçu pour un dossier, à la place de `CREATED_ACCOUNT`. **Aucun événement** lors du passage `COMPLETED → TO_PROCESS` : le dossier est identique pour vous ; la vérification aboutit ensuite à `VERIFIED_ACCOUNT` ou `DENIED_ACCOUNT`. `dossierUrl` / `dossierPdfUrl` sont désormais renseignés dès `TO_PROCESS`. L'ouverture se fait partenaire par partenaire, après recette.
+
+---
+
+## 7. Scénarios de test manuel (préprod)
+
+Préparation : flag `tenant_completed_optin` actif à 100 %, `tenant_lottery` OFF puis ON, deux partenaires DFC de test `P_open` et `P_closed`, `partner_completed_optin` actif avec `P_open` listé (sauf S1-S2). Vérifications : `tenant.status`, `tenant_userapi`, `tenant_log`, `callback_log` (`partner_id`, `tenant_status`, payload), ELK.
+
+| # | Scénario | Attendu |
+|---|---|---|
+| S1 | Flag `partner_completed_optin` **inactif**, `P_open` listé : liaison DFC d'un dossier COMPLETED | Bascule TO_PROCESS, mail 174, `CREATED_ACCOUNT` avec `status=TO_PROCESS` |
+| S2 | Idem, flag actif mais liste vide | Idem S1 |
+| S3 | Flag actif, compte lié à `P_open` avant soumission → signature | `COMPLETED`, `COMPLETED_ACCOUNT` avec `status=COMPLETED` aux deux niveaux, `dossierUrl` / `dossierPdfUrl` renseignés ; GET api-partner : `optInEligible=false`, pas de `validationRequested` ; encart opt-in visible côté locataire |
+| S4 | S3 → opt-in « oui » (loterie OFF) | TO_PROCESS, **aucune** nouvelle ligne `callback_log` ; annulation → COMPLETED, nouveau `COMPLETED_ACCOUNT` |
+| S5 | S3 → loterie ON, ticket tiré | TO_PROCESS sans webhook ; validation opérateur → `VERIFIED_ACCOUNT` |
+| S6 | S3 → liaison à `P_closed` | Bascule TO_PROCESS, mail 174 nommant `P_closed`, `CREATED_ACCOUNT` à `P_closed` seulement ; `optInEligible=false` côté locataire (plus éligible) ; re-soumission ultérieure → TO_PROCESS |
+| S7 | Dossier COMPLETED sans partenaire → liaison à `P_open` | Pas de bascule, `COMPLETED_ACCOUNT`, `callback_log.tenant_status=COMPLETED` |
+| S8 | BO : renvoi manuel d'un COMPLETED vers `P_open` / vers `P_closed` | `COMPLETED_ACCOUNT` / `CREATED_ACCOUNT` + `log.error` « Defensive callback type downgrade » (cas anormal, ne se produit que si `P_closed` est lié à un COMPLETED) |
+| S9 | BO : saisie de `dfconnect-proprietaire`, d'un nom inconnu, d'une liste avec espaces | Refus avec message / refus listant l'inconnu / liste normalisée enregistrée |
+| S10 | DFC `GET /dfc/tenant/profile` d'un COMPLETED avec `P_closed` | Réponse `TO_PROCESS` (bascule) **sans** `log.error` de masquage |
+
+---
+
+## 8. Observabilité
+
+- ELK, zéro occurrence attendue : « `Defensive status masking triggered` » (mappers) et « `Defensive callback type downgrade` » (webhook).
+- Invariant SQL (zéro ligne attendue) : dossiers COMPLETED liés à un partenaire n'ayant pas intégré COMPLETED :
+```sql
+SELECT t.id, ua.name
+FROM tenant t
+JOIN tenant_userapi tua ON tua.tenant_id = t.id
+JOIN user_api ua ON ua.id = tua.userapi_id
+WHERE t.status = 'COMPLETED'
+  AND ua.name <> ALL (string_to_array(
+        (SELECT COALESCE(opted_in_partners, '') FROM feature_flag WHERE key = 'partner_completed_optin'), ','));
+```
+- `callback_log` : `SELECT partner_id, count(*) FROM callback_log WHERE tenant_status = 'COMPLETED' GROUP BY 1` — uniquement des partenaires listés.
+- Effet attendu sur la loterie : baisse du `bypass_count` (`lottery_draw`), les liaisons vers des partenaires ayant intégré COMPLETED n'entrant plus en file.
+
+---
+
+## 9. Limites et évolutions
+
+- **Pas de rollback par partenaire** : retirer un nom de la liste (ou désactiver le flag) n'agit que sur les nouvelles soumissions et liaisons. Les dossiers COMPLETED déjà liés à ce partenaire le restent ; ses lectures sont alors masquées avec `log.error` (§4), et l'invariant SQL §8 les liste. Le rollback global `/completed-rollback` (completed-optin.md §9) reste disponible.
+- **Propriétaire** hors périmètre (mappers owner inconditionnels, mails « candidat validé / non validé »).
+- **Retour en `INCOMPLETE`** non notifié, comme pour `TO_PROCESS` aujourd'hui.
+- **COUPLE / GROUP** : suivent l'extension de l'opt-in locataire.
+- Séquence de déploiement : tous les modules (common-library, api-tenant, bo, task-scheduler, pdf-generator, api-owner) **avant** toute activation — l'enum `PartnerCallBackType` est partagée, et le partage en TO_PROCESS touche api-tenant et pdf-generator.

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkController.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkController.java
@@ -49,7 +49,7 @@ public class ApartmentSharingLinkController {
     public ResponseEntity<ApartmentSharingLinkModel> updateApartmentSharingLinksStatus( @RequestParam boolean isFullData) {
         Tenant tenant = authenticationFacade.getLoggedTenant();
         ApartmentSharing apartmentSharing = tenant.getApartmentSharing();
-        requireCompletedOrValidatedDossier(apartmentSharing);
+        requireShareableDossier(apartmentSharing);
         ApartmentSharingLinkModel defaultLink = apartmentSharingLinkService.getDefaultLink(apartmentSharing, tenant, isFullData);
         return ResponseEntity.ok(defaultLink);
     }
@@ -117,11 +117,10 @@ public class ApartmentSharingLinkController {
         return ResponseEntity.ok().build();
     }
 
-    // Sharing by link is reserved to complete, submitted dossiers:
-    // VALIDATED (operator-verified) or COMPLETED (non verified, opt-in flow)
-    private void requireCompletedOrValidatedDossier(ApartmentSharing apartmentSharing) {
-        if (apartmentSharing == null || !apartmentSharing.getStatus().isCompletedOrValidated()) {
-            throw new TenantIllegalStateException("Sharing a dossier by link requires a validated or completed dossier");
+    // Sharing by link is reserved to submitted dossiers (TO_PROCESS, COMPLETED or VALIDATED)
+    private void requireShareableDossier(ApartmentSharing apartmentSharing) {
+        if (apartmentSharing == null || !apartmentSharing.getStatus().isCompletedOrBetter()) {
+            throw new TenantIllegalStateException("Sharing a dossier by link requires a submitted dossier");
         }
     }
 

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantController.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantController.java
@@ -14,6 +14,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -30,11 +31,17 @@ import static org.springframework.http.ResponseEntity.ok;
 @Slf4j
 public class DfcTenantController {
 
+    private final GroupedOpenApi allOpenApi;
     private final AuthenticationFacade authenticationFacade;
     private final TenantMapper tenantMapper;
     private final TenantService tenantService;
     private final UserService userService;
     private final UserApiService userApiService;
+
+
+    DfcTenantController(GroupedOpenApi allOpenApi) {
+        this.allOpenApi = allOpenApi;
+    }
 
 
     @ApiOperation(value = "Get tenant profile for partner", notes = "Retrieves the tenant profile associated with the authenticated partner.")
@@ -61,6 +68,8 @@ public class DfcTenantController {
         } else {
             userService.linkTenantToPartner(tenant, partner, null);
         }
+        // Linking may have switched a COMPLETED dossier back to TO_PROCESS so re-fetch the tenant
+        tenant = tenantService.findById(tenant.getId());
         UserApi userApi = userApiService.findByName(authenticationFacade.getKeycloakClientId()).orElse(null);
         return ok(tenantMapper.toTenantModelDfc(tenant, userApi));
     }

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantController.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantController.java
@@ -14,7 +14,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,17 +30,11 @@ import static org.springframework.http.ResponseEntity.ok;
 @Slf4j
 public class DfcTenantController {
 
-    private final GroupedOpenApi allOpenApi;
     private final AuthenticationFacade authenticationFacade;
     private final TenantMapper tenantMapper;
     private final TenantService tenantService;
     private final UserService userService;
     private final UserApiService userApiService;
-
-
-    DfcTenantController(GroupedOpenApi allOpenApi) {
-        this.allOpenApi = allOpenApi;
-    }
 
 
     @ApiOperation(value = "Get tenant profile for partner", notes = "Retrieves the tenant profile associated with the authenticated partner.")

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/mapper/TenantMapper.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/mapper/TenantMapper.java
@@ -6,10 +6,8 @@ import fr.dossierfacile.api.front.model.tenant.*;
 import fr.dossierfacile.common.entity.*;
 import fr.dossierfacile.common.enums.ApartmentSharingLinkType;
 import fr.dossierfacile.common.enums.ApplicationType;
-import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.mapper.MapDocumentCategories;
 import fr.dossierfacile.common.mapper.MasksCompletedStatusForPartner;
-import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
 import org.mapstruct.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +25,7 @@ import java.util.function.Predicate;
 
 @Component
 @Mapper(componentModel = "spring")
-public abstract class TenantMapper implements MasksCompletedStatusForPartner {
+public abstract class TenantMapper extends MasksCompletedStatusForPartner {
     private static final String DOCUMENT_DIRECT_PATH = "api/document/resource";
     protected static final String DOCUMENT_LINK_PATH = "api/application/links";
     private static final String PREVIEW_PATH = "api/file/preview";
@@ -44,22 +42,20 @@ public abstract class TenantMapper implements MasksCompletedStatusForPartner {
     protected String tenantBaseUrl;
 
     @Autowired
-    protected OperatorReviewPolicy operatorReviewPolicy;
-
-    @Autowired
     protected LotteryTicketService lotteryTicketService;
 
     @Mapping(target = "honorDeclaration", expression = "java(mapHonorDeclaration(tenant))")
-    @Mapping(target = "optInEligible", expression = "java(operatorReviewPolicy.canRequestOperatorReview(tenant))")
     @Mapping(source = "tenant", target = "franceConnectIdentity", qualifiedByName = "franceConnectIdentity")
     public abstract TenantModel toTenantModel(Tenant tenant, @Context UserApi userApi);
 
-    // Lottery state: not shown to partners
+    // Opt-in state (eligibility, choice, lottery): never shown to partners
     @AfterMapping
-    protected void enrichWithLotteryStatus(Tenant tenant, @MappingTarget TenantModel tenantModel, @Context UserApi userApi) {
+    protected void enrichWithOptInState(Tenant tenant, @MappingTarget TenantModel tenantModel, @Context UserApi userApi) {
         if (userApi != null) {
+            tenantModel.setValidationRequested(null);
             return;
         }
+        tenantModel.setOptInEligible(operatorReviewPolicy.canRequestOperatorReview(tenant));
         lotteryTicketService.getPublicStatus(tenant.getId()).ifPresent(view -> {
             tenantModel.setLotteryStatus(view.status());
             tenantModel.setNextEligibleDate(view.nextEligibleDate());
@@ -211,8 +207,8 @@ public abstract class TenantMapper implements MasksCompletedStatusForPartner {
         String token = null;
         String tokenPublic = null;
 
-        // Only expose sharing tokens once the apartment dossier is fully validated
-        if (apartmentSharingModel.getStatus() == TenantFileStatus.VALIDATED) {
+        // Only expose sharing tokens once the apartment dossier is submitted (TO_PROCESS, COMPLETED or VALIDATED)
+        if (apartmentSharingModel.getStatus() != null && apartmentSharingModel.getStatus().isCompletedOrBetter()) {
             List<ApartmentSharingLink> links = tenant.getApartmentSharing().getApartmentSharingLinks();
             if (links != null) {
                 // fullLink: PARTNER or LINK entry with fullData = true (full application)

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/ApartmentSharingServiceImpl.java
@@ -188,7 +188,7 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
 
     // token is only used for logs and error reporting, null when the request does not come from a sharing link
     private void requestFullPdfGeneration(ApartmentSharing apartmentSharing, String token) {
-        checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(apartmentSharing.getId(), token);
+        checkAllTenantsSubmittedAndAllDocumentsNotNull(apartmentSharing.getId(), token);
 
         FileStatus pdfStatus = apartmentSharing.getDossierPdfDocumentStatus() == null ? FileStatus.NONE : apartmentSharing.getDossierPdfDocumentStatus();
         switch (pdfStatus) {
@@ -393,7 +393,7 @@ public class ApartmentSharingServiceImpl implements ApartmentSharingService {
         zos.closeEntry();
     }
 
-    private void checkAllTenantsCompletedOrValidatedAndAllDocumentsNotNull(long apartmentSharingId, String token) {
+    private void checkAllTenantsSubmittedAndAllDocumentsNotNull(long apartmentSharingId, String token) {
         int numberOfTenants = tenantRepository.countTenantsBlockingFullPdfGeneration(apartmentSharingId);
         if (numberOfTenants > 0) {
             if (token != null) {

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantServiceImpl.java
@@ -25,7 +25,6 @@ import fr.dossierfacile.common.repository.ApartmentSharingLinkRepository;
 import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.ConfirmationTokenService;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
@@ -70,7 +69,6 @@ public class TenantServiceImpl implements TenantService {
     private final TenantMapperForMail tenantMapperForMail;
     private final OperatorReviewPolicy operatorReviewPolicy;
     private final TenantStatusService tenantStatusService;
-    private final ApartmentSharingCommonService apartmentSharingCommonService;
     private final FeatureFlagService featureFlagService;
     private final LotteryTicketService lotteryTicketService;
 
@@ -93,7 +91,6 @@ public class TenantServiceImpl implements TenantService {
                              TenantMapperForMail tenantMapperForMail,
                              OperatorReviewPolicy operatorReviewPolicy,
                              @Lazy TenantStatusService tenantStatusService,
-                             ApartmentSharingCommonService apartmentSharingCommonService,
                              FeatureFlagService featureFlagService,
                              LotteryTicketService lotteryTicketService) {
         this.apartmentSharingRepository = apartmentSharingRepository;
@@ -112,7 +109,6 @@ public class TenantServiceImpl implements TenantService {
         this.tenantMapperForMail = tenantMapperForMail;
         this.operatorReviewPolicy = operatorReviewPolicy;
         this.tenantStatusService = tenantStatusService;
-        this.apartmentSharingCommonService = apartmentSharingCommonService;
         this.featureFlagService = featureFlagService;
         this.lotteryTicketService = lotteryTicketService;
     }
@@ -233,7 +229,7 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public void sendFileByMail(Tenant tenant, ShareFileByMailForm form) {
-        requireCompletedOrValidatedDossier(tenant);
+        requireShareableDossier(tenant);
         UUID token = UUID.randomUUID();
         LocalDateTime date = LocalDateTime.now().minusDays(1);
         List<ApartmentSharingLink> existingASL = apartmentSharingLinkRepository.findByApartmentSharingAndCreationDateIsAfterAndDeletedIsFalse(tenant.getApartmentSharing(), date);
@@ -267,7 +263,7 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public String createSharingLink(Tenant tenant, ShareFileByLinkForm form) {
-        requireCompletedOrValidatedDossier(tenant);
+        requireShareableDossier(tenant);
         UUID token = UUID.randomUUID();
         ApartmentSharingLink apartmentSharingLink = ApartmentSharingLink.builder()
                 .apartmentSharing(tenant.getApartmentSharing())
@@ -285,10 +281,10 @@ public class TenantServiceImpl implements TenantService {
         return path + token;
     }
 
-    // Sharing by link or mail is reserved to VALIDATED or COMPLETED dossiers
-    private void requireCompletedOrValidatedDossier(Tenant tenant) {
-        if (!tenant.getApartmentSharing().getStatus().isCompletedOrValidated()) {
-            throw new TenantIllegalStateException("Sharing a dossier by link or mail requires a validated or completed dossier");
+    // Sharing by link or mail is reserved to submitted dossiers (TO_PROCESS, COMPLETED or VALIDATED)
+    private void requireShareableDossier(Tenant tenant) {
+        if (!tenant.getApartmentSharing().getStatus().isCompletedOrBetter()) {
+            throw new TenantIllegalStateException("Sharing a dossier by link or mail requires a submitted dossier");
         }
     }
 
@@ -310,11 +306,6 @@ public class TenantServiceImpl implements TenantService {
         tenantRepository.save(tenant);
         logService.saveLog(validationRequested ? LogType.VALIDATION_REQUESTED : LogType.VALIDATION_DECLINED, tenant.getId());
         Tenant updatedTenant = tenantStatusService.updateTenantStatus(tenant);
-        if (previousStatus == TenantFileStatus.COMPLETED && updatedTenant.getStatus() != TenantFileStatus.COMPLETED) {
-            // The full PDF was rendered with the COMPLETED design: it must not
-            // survive the switch out of COMPLETED
-            apartmentSharingCommonService.resetDossierPdfGenerated(updatedTenant.getApartmentSharing());
-        }
         // Entering the verification queue: reuse the standard "waiting for review" email
         if (validationRequested && previousStatus == TenantFileStatus.COMPLETED
                 && updatedTenant.getStatus() == TenantFileStatus.TO_PROCESS) {

--- a/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantStatusServiceImpl.java
+++ b/dossierfacile-api-tenant/src/main/java/fr/dossierfacile/api/front/service/TenantStatusServiceImpl.java
@@ -62,6 +62,9 @@ public class TenantStatusServiceImpl implements TenantStatusService {
                     if (previousStatus == TenantFileStatus.INCOMPLETE) {
                         partnerCallBackService.sendCallBack(tenant, PartnerCallBackType.CREATED_ACCOUNT);
                     }
+                } else if (newTenantStatus == TenantFileStatus.COMPLETED && previousStatus == TenantFileStatus.INCOMPLETE) {
+                    // Submission only: moves between TO_PROCESS and COMPLETED are silent for partners
+                    partnerCallBackService.sendCallBack(tenant, PartnerCallBackType.COMPLETED_ACCOUNT);
                 }
             }
             apartmentSharingService.refreshUpdateDate(tenant.getApartmentSharing());

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkControllerTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/controller/ApartmentSharingLinkControllerTest.java
@@ -137,13 +137,25 @@ public class ApartmentSharingLinkControllerTest {
                                     Collections.emptyList()
                             )
                     ),
-                    Pair.of("Should respond 409 when dossier is neither COMPLETED nor VALIDATED",
+                    Pair.of("Should respond 200 when dossier is TO_PROCESS",
+                            new ControllerParameter<>(
+                                    new UpdateDefaultLinkTestParameter(),
+                                    200,
+                                    jwtTokenWithDossier,
+                                    (v) -> {
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.TO_PROCESS));
+                                        return v;
+                                    },
+                                    Collections.emptyList()
+                            )
+                    ),
+                    Pair.of("Should respond 409 when dossier is not submitted",
                             new ControllerParameter<>(
                                     new UpdateDefaultLinkTestParameter(),
                                     409,
                                     jwtTokenWithDossier,
                                     (v) -> {
-                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.TO_PROCESS));
+                                        when(self.authenticationFacade.getLoggedTenant()).thenReturn(tenantWithDossierStatus(TenantFileStatus.INCOMPLETE));
                                         return v;
                                     },
                                     Collections.emptyList()

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantControllerTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantControllerTest.java
@@ -190,6 +190,7 @@ class DfcTenantControllerTest {
                                         when(self.authenticationFacade.getKeycloakUserId()).thenReturn("keycloak_id");
                                         when(self.tenantService.findByKeycloakId("keycloak_id")).thenReturn(tenant);
                                         when(self.userApiService.findByName("client_id")).thenReturn(Optional.of(userApi));
+                                        when(self.tenantService.findById(1L)).thenReturn(tenant);
                                         return v;
                                     },
                                     List.of(
@@ -214,6 +215,7 @@ class DfcTenantControllerTest {
                                         when(self.tenantService.findByEmail("test@test.fr")).thenReturn(Optional.of(tenant));
                                         when(self.authenticationFacade.getKeycloakUserId()).thenReturn("keycloak_id");
                                         when(self.userApiService.findByName("client_id")).thenReturn(Optional.of(userApi));
+                                        when(self.tenantService.findById(1L)).thenReturn(tenant);
                                         return v;
                                     },
                                     List.of(
@@ -241,6 +243,7 @@ class DfcTenantControllerTest {
                                         when(self.authenticationFacade.getKeycloakUser()).thenReturn(keycloakUser);
                                         when(self.tenantService.registerFromKeycloakUser(keycloakUser, "client_id", null)).thenReturn(tenant);
                                         when(self.userApiService.findByName("client_id")).thenReturn(Optional.of(userApi));
+                                        when(self.tenantService.findById(1L)).thenReturn(tenant);
                                         return v;
                                     },
                                     List.of(

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/dfc/controller/DfcTenantsControllerIntegrationTest.java
@@ -192,8 +192,24 @@ class DfcTenantsControllerIntegrationTest {
         expectedDossierPdfUrl = "https://api.test.com/api/application/fullPdf/" + fullLinkToken;
     }
 
+    // A submitted dossier (TO_PROCESS) is shareable: tokens and dossier URLs are exposed
     @Test
-    void shouldDisplayLinkPathToDocumentsWhenDossierIsNotValidated() throws Exception {
+    void shouldDisplayTokensAndLinkPathToDocumentsWhenDossierIsToProcess() throws Exception {
+        mockMvc.perform(get("/dfc/api/v1/tenants/{id}", tenantId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.apartmentSharing.token", is(expectedToken)))
+                .andExpect(jsonPath("$.apartmentSharing.tokenPublic", is(expectedPublicToken)))
+                .andExpect(jsonPath("$.apartmentSharing.dossierUrl", is(expectedDossierUrl)))
+                .andExpect(jsonPath("$.apartmentSharing.dossierPdfUrl", is(expectedDossierPdfUrl)))
+                .andExpect(jsonPath("$.apartmentSharing.tenants[0].documents[0].name",
+                        is(expectedDocumentUrl)));
+    }
+
+    @Test
+    void shouldNotDisplayTokensWhenDossierIsIncomplete() throws Exception {
+        Tenant tenant = em.find(Tenant.class, tenantId);
+        tenant.setStatus(TenantFileStatus.INCOMPLETE);
+
         mockMvc.perform(get("/dfc/api/v1/tenants/{id}", tenantId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.apartmentSharing.token").doesNotExist())

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/mapper/TenantMapperTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/mapper/TenantMapperTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 class TenantMapperTest {
 
     private TenantMapperImpl mapper;
+    private OperatorReviewPolicy operatorReviewPolicy;
 
     @BeforeEach
     void setUp() {
@@ -51,7 +52,8 @@ class TenantMapperTest {
         mapper.applicationBaseUrl = "https://api.example.com";
         mapper.tenantBaseUrl = "https://example.com";
         mapper.minBrokenRulesLevel = DocumentRuleLevel.WARN;
-        mapper.operatorReviewPolicy = mock(OperatorReviewPolicy.class);
+        operatorReviewPolicy = mock(OperatorReviewPolicy.class);
+        mapper.setOperatorReviewPolicy(operatorReviewPolicy);
         LotteryTicketService lotteryTicketService = mock(LotteryTicketService.class);
         when(lotteryTicketService.getPublicStatus(any())).thenReturn(Optional.empty());
         mapper.lotteryTicketService = lotteryTicketService;
@@ -195,6 +197,23 @@ class TenantMapperTest {
 
             String docUrl = model.getDocuments().getFirst().getName();
             assertThat(docUrl).isEqualTo("https://api.example.com/api/document/resource/doc-123.pdf");
+            assertThat(model.getApartmentSharing().getToken()).isEqualTo(fullLinkToken.toString());
+            assertThat(model.getApartmentSharing().getDossierPdfUrl()).isEqualTo("https://api.example.com/api/application/fullPdf/" + fullLinkToken);
+            assertThat(model.getApartmentSharing().getDossierUrl()).isEqualTo("https://example.com/file/" + fullLinkToken);
+        }
+
+        /*
+            A submitted but not yet verified dossier (TO_PROCESS) can be shared:
+            token, dossierPdfUrl and dossierUrl must be set as for a VALIDATED dossier.
+        */
+        @Test
+        void shouldExposeTokensWhenNoUserApiAndTenantIsToProcess() {
+            UUID fullLinkToken = UUID.randomUUID();
+            Tenant tenant = buildTenantWithDocument(TenantFileStatus.TO_PROCESS);
+            setupApartmentSharing(tenant, List.of(buildFullLink(fullLinkToken)));
+
+            TenantModel model = mapper.toTenantModel(tenant, null);
+
             assertThat(model.getApartmentSharing().getToken()).isEqualTo(fullLinkToken.toString());
             assertThat(model.getApartmentSharing().getDossierPdfUrl()).isEqualTo("https://api.example.com/api/application/fullPdf/" + fullLinkToken);
             assertThat(model.getApartmentSharing().getDossierUrl()).isEqualTo("https://example.com/file/" + fullLinkToken);
@@ -779,8 +798,8 @@ class TenantMapperTest {
             return tenant;
         }
 
-        // The COMPLETED status must never reach a partner facing DTO: this test
-        // protects the defensive masking from being removed as dead code
+        // The COMPLETED status must never reach a DTO served to a partner that did not
+        // opt in: this test protects the defensive masking from being removed as dead code
         @Test
         void shouldMaskCompletedStatusForPartnerContext() {
             UserApi userApi = new UserApi();
@@ -798,6 +817,55 @@ class TenantMapperTest {
 
             assertThat(model.getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
             assertThat(model.getApartmentSharing().getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+        }
+
+        @Test
+        void shouldKeepCompletedStatusForAnOptedInPartner() {
+            UserApi userApi = new UserApi();
+            userApi.setId(200L);
+            when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(true);
+
+            TenantModel model = mapper.toTenantModel(completedTenant(), userApi);
+
+            assertThat(model.getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+            assertThat(model.getApartmentSharing().getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+        }
+    }
+
+    @Nested
+    class OptInStateExposure {
+
+        private Tenant tenantWithChoice() {
+            Tenant tenant = buildTenantWithDocument(TenantFileStatus.COMPLETED);
+            tenant.setValidationRequested(true);
+            setupApartmentSharing(tenant, new ArrayList<>());
+            return tenant;
+        }
+
+        @Test
+        void shouldExposeOptInStateOnTenantOwnProfile() {
+            Tenant tenant = tenantWithChoice();
+            when(operatorReviewPolicy.canRequestOperatorReview(tenant)).thenReturn(true);
+
+            TenantModel model = mapper.toTenantModel(tenant, null);
+
+            assertThat(model.isOptInEligible()).isTrue();
+            assertThat(model.getValidationRequested()).isTrue();
+        }
+
+        // The opt-in state is the tenant's business, never a partner's
+        @Test
+        void shouldHideOptInStateFromPartners() {
+            Tenant tenant = tenantWithChoice();
+            UserApi userApi = new UserApi();
+            userApi.setId(200L);
+            when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(true);
+
+            TenantModel model = mapper.toTenantModel(tenant, userApi);
+
+            assertThat(model.isOptInEligible()).isFalse();
+            assertThat(model.getValidationRequested()).isNull();
+            org.mockito.Mockito.verify(operatorReviewPolicy, org.mockito.Mockito.never()).canRequestOperatorReview(any());
         }
     }
 }

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantServiceImplTest.java
@@ -24,7 +24,6 @@ import fr.dossierfacile.common.repository.ApartmentSharingLinkRepository;
 import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.DocumentAnalysisReportRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
@@ -37,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -82,8 +80,6 @@ class TenantServiceImplTest {
     private OperatorReviewPolicy operatorReviewPolicy;
     @Mock
     private TenantStatusService tenantStatusService;
-    @Mock
-    private ApartmentSharingCommonService apartmentSharingCommonService;
     @Mock
     private FeatureFlagService featureFlagService;
     @Mock
@@ -247,9 +243,20 @@ class TenantServiceImplTest {
     }
 
     @Test
-    void createSharingLink_isRefusedForNonCompletedOrValidatedDossier() {
+    void createSharingLink_isAllowedForToProcessDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.TO_PROCESS);
+        ShareFileByLinkForm form = ShareFileByLinkForm.builder().title("Agence").fullData(true).daysValid(30).build();
+
+        String url = tenantService.createSharingLink(tenant, form);
+
+        assertTrue(url.startsWith("/file/"));
+        verify(apartmentSharingLinkRepository).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
+    void createSharingLink_isRefusedForNonSubmittedDossier() {
         for (TenantFileStatus status : new TenantFileStatus[]{
-                TenantFileStatus.TO_PROCESS, TenantFileStatus.INCOMPLETE, TenantFileStatus.DECLINED}) {
+                TenantFileStatus.INCOMPLETE, TenantFileStatus.DECLINED, TenantFileStatus.ARCHIVED}) {
             Tenant tenant = aloneTenantWithStatus(status);
             ShareFileByLinkForm form = ShareFileByLinkForm.builder().title("Agence").daysValid(30).build();
 
@@ -273,8 +280,8 @@ class TenantServiceImplTest {
     }
 
     @Test
-    void sendFileByMail_isRefusedForNonCompletedOrValidatedDossier() {
-        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.TO_PROCESS);
+    void sendFileByMail_isRefusedForNonSubmittedDossier() {
+        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.INCOMPLETE);
         ShareFileByMailForm form = ShareFileByMailForm.builder()
                 .email("owner@example.com").title("Agence").message("Bonjour").daysValid(7).build();
 
@@ -282,41 +289,10 @@ class TenantServiceImplTest {
         verifyNoInteractions(mailService);
     }
 
-    @Test
-    void updateValidationRequest_resetsFullPdf_whenDossierLeavesCompleted() {
-        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
-        when(operatorReviewPolicy.canRequestOperatorReview(tenant)).thenReturn(true);
-        when(tenantStatusService.updateTenantStatus(tenant)).thenAnswer(invocation -> {
-            tenant.setStatus(TenantFileStatus.TO_PROCESS);
-            return tenant;
-        });
-        TransactionSynchronizationManager.initSynchronization();
-
-        try {
-            tenantService.updateValidationRequest(tenant, true);
-        } finally {
-            TransactionSynchronizationManager.clearSynchronization();
-        }
-
-        // The full PDF was rendered with the "non verified" design and must be dropped
-        verify(apartmentSharingCommonService).resetDossierPdfGenerated(tenant.getApartmentSharing());
-    }
-
-    @Test
-    void updateValidationRequest_keepsFullPdf_whenDossierStaysCompleted() {
-        Tenant tenant = aloneTenantWithStatus(TenantFileStatus.COMPLETED);
-        when(operatorReviewPolicy.canRequestOperatorReview(tenant)).thenReturn(true);
-        when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
-
-        tenantService.updateValidationRequest(tenant, false);
-
-        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
-    }
-
     // On a reviewed dossier the choice is recorded without any immediate effect:
     // it only applies to the next re-submission
     @Test
-    void updateValidationRequest_onValidatedDossier_persistsChoiceWithoutTouchingStatusOrPdf() {
+    void updateValidationRequest_onValidatedDossier_persistsChoiceWithoutTouchingStatus() {
         Tenant tenant = aloneTenantWithStatus(TenantFileStatus.VALIDATED);
         when(operatorReviewPolicy.canRequestOperatorReview(tenant)).thenReturn(true);
         when(tenantStatusService.updateTenantStatus(tenant)).thenReturn(tenant);
@@ -326,7 +302,6 @@ class TenantServiceImplTest {
         assertEquals(TenantFileStatus.VALIDATED, updated.getStatus());
         assertEquals(Boolean.FALSE, updated.getValidationRequested());
         verify(logService).saveLog(LogType.VALIDATION_DECLINED, tenant.getId());
-        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
         verifyNoInteractions(mailService);
     }
 
@@ -346,7 +321,6 @@ class TenantServiceImplTest {
         assertEquals(Boolean.FALSE, updated.getValidationRequested());
         verify(logService).saveLog(LogType.VALIDATION_DECLINED, tenant.getId());
         verify(tenantStatusService).updateTenantStatus(tenant);
-        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
         verifyNoInteractions(mailService);
     }
 
@@ -375,7 +349,6 @@ class TenantServiceImplTest {
         assertEquals(TenantFileStatus.DECLINED, updated.getStatus());
         assertEquals(Boolean.TRUE, updated.getValidationRequested());
         verify(logService).saveLog(LogType.VALIDATION_REQUESTED, tenant.getId());
-        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
         verifyNoInteractions(mailService);
     }
 
@@ -395,7 +368,6 @@ class TenantServiceImplTest {
         verify(logService).saveLog(LogType.VALIDATION_REQUESTED, tenant.getId());
         // No queue entry, no queue position, no mail: everything happens at draw time
         verifyNoInteractions(tenantStatusService, mailService);
-        verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
     }
 
     @Test

--- a/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantStatusServiceImplTest.java
+++ b/dossierfacile-api-tenant/src/test/java/fr/dossierfacile/api/front/service/TenantStatusServiceImplTest.java
@@ -1,0 +1,153 @@
+package fr.dossierfacile.api.front.service;
+
+import fr.dossierfacile.api.front.service.interfaces.ApartmentSharingService;
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.PartnerCallBackType;
+import fr.dossierfacile.common.enums.QueueEntrySource;
+import fr.dossierfacile.common.enums.TenantFileStatus;
+import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
+import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
+import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
+import fr.dossierfacile.common.service.interfaces.TenantCommonService;
+import fr.dossierfacile.common.service.interfaces.TenantLogCommonService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TenantStatusServiceImplTest {
+
+    @Mock
+    private ApartmentSharingService apartmentSharingService;
+    @Mock
+    private PartnerCallBackService partnerCallBackService;
+    @Mock
+    private TenantCommonRepository tenantRepository;
+    @Mock
+    private TenantCommonService tenantCommonService;
+    @Mock
+    private TenantLogCommonService tenantLogCommonService;
+    @Mock
+    private OperatorReviewPolicy operatorReviewPolicy;
+    @Mock
+    private LotteryTicketService lotteryTicketService;
+
+    @InjectMocks
+    private TenantStatusServiceImpl service;
+
+    // The computed status is stubbed on a spy; the policy decides the persisted one
+    private Tenant tenantGoingFrom(TenantFileStatus previous, TenantFileStatus computed, TenantFileStatus resolved) {
+        Tenant tenant = spy(Tenant.builder().id(1L).status(previous).apartmentSharing(new ApartmentSharing()).build());
+        doReturn(computed).when(tenant).computeStatus();
+        when(operatorReviewPolicy.resolveStatus(tenant, computed)).thenReturn(resolved);
+        if (resolved != TenantFileStatus.VALIDATED && resolved != previous) {
+            when(tenantRepository.save(tenant)).thenReturn(tenant);
+        }
+        return tenant;
+    }
+
+    @Nested
+    class EnteringCompleted {
+
+        @Test
+        void submission_emitsCompletedAccount() {
+            Tenant tenant = tenantGoingFrom(TenantFileStatus.INCOMPLETE, TenantFileStatus.TO_PROCESS, TenantFileStatus.COMPLETED);
+
+            Tenant updated = service.updateTenantStatus(tenant);
+
+            assertThat(updated.getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+            verify(partnerCallBackService).sendCallBack(tenant, PartnerCallBackType.COMPLETED_ACCOUNT);
+            verify(tenantLogCommonService, never()).logQueueEntered(anyLong(), any());
+        }
+
+        // For the partner the dossier is unchanged, as when it enters the queue
+        @Test
+        void withdrawingTheReviewRequest_isSilent() {
+            Tenant tenant = tenantGoingFrom(TenantFileStatus.TO_PROCESS, TenantFileStatus.TO_PROCESS, TenantFileStatus.COMPLETED);
+
+            service.updateTenantStatus(tenant);
+
+            verify(partnerCallBackService, never()).sendCallBack(any(Tenant.class), any(PartnerCallBackType.class));
+        }
+    }
+
+    @Nested
+    class EnteringTheQueue {
+
+        @Test
+        void submission_emitsCreatedAccount() {
+            Tenant tenant = tenantGoingFrom(TenantFileStatus.INCOMPLETE, TenantFileStatus.TO_PROCESS, TenantFileStatus.TO_PROCESS);
+
+            service.updateTenantStatus(tenant);
+
+            verify(tenantLogCommonService).logQueueEntered(1L, QueueEntrySource.SUBMISSION);
+            verify(partnerCallBackService).sendCallBack(tenant, PartnerCallBackType.CREATED_ACCOUNT);
+        }
+
+        // For the partner the dossier is unchanged: the next event is the operator's verdict
+        @Test
+        void fromCompleted_entersTheQueueSilently() {
+            Tenant tenant = tenantGoingFrom(TenantFileStatus.COMPLETED, TenantFileStatus.TO_PROCESS, TenantFileStatus.TO_PROCESS);
+
+            service.updateTenantStatus(tenant);
+
+            verify(tenantLogCommonService).logQueueEntered(1L, QueueEntrySource.SUBMISSION);
+            verify(partnerCallBackService, never()).sendCallBack(any(Tenant.class), any(PartnerCallBackType.class));
+        }
+
+        // Historical behaviour, unchanged: no webhook when a reviewed dossier is edited
+        @Test
+        void fromValidated_entersTheQueueSilently() {
+            Tenant tenant = tenantGoingFrom(TenantFileStatus.VALIDATED, TenantFileStatus.TO_PROCESS, TenantFileStatus.TO_PROCESS);
+
+            service.updateTenantStatus(tenant);
+
+            verify(partnerCallBackService, never()).sendCallBack(any(Tenant.class), any(PartnerCallBackType.class));
+        }
+    }
+
+    @Test
+    void declined_emitsDeniedAccount() {
+        Tenant tenant = tenantGoingFrom(TenantFileStatus.TO_PROCESS, TenantFileStatus.DECLINED, TenantFileStatus.DECLINED);
+
+        service.updateTenantStatus(tenant);
+
+        verify(lotteryTicketService).consumeDrawnTicket(1L);
+        verify(partnerCallBackService).sendCallBack(tenant, PartnerCallBackType.DENIED_ACCOUNT);
+    }
+
+    @Test
+    void validated_delegatesToTheCommonService() {
+        Tenant tenant = tenantGoingFrom(TenantFileStatus.TO_PROCESS, TenantFileStatus.VALIDATED, TenantFileStatus.VALIDATED);
+
+        service.updateTenantStatus(tenant);
+
+        verify(tenantCommonService).changeTenantStatusToValidated(tenant);
+        verify(partnerCallBackService, never()).sendCallBack(any(Tenant.class), any(PartnerCallBackType.class));
+    }
+
+    @Test
+    void unchangedStatus_doesNothing() {
+        Tenant tenant = tenantGoingFrom(TenantFileStatus.COMPLETED, TenantFileStatus.TO_PROCESS, TenantFileStatus.COMPLETED);
+
+        service.updateTenantStatus(tenant);
+
+        verify(tenantRepository, never()).save(any());
+        verify(partnerCallBackService, never()).sendCallBack(any(Tenant.class), any(PartnerCallBackType.class));
+        verify(apartmentSharingService, never()).refreshUpdateDate(any());
+    }
+}

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
@@ -87,7 +87,7 @@ public class BOFeatureFlagsController {
                 .toList();
         if (!unknownNames.isEmpty()) {
             redirectAttributes.addFlashAttribute("errorMessage",
-                    "Client id(s) inconnu(s), liste non enregistrée : " + String.join(", ", unknownNames));
+                    "Partenaire(s) inconnu(s), liste non enregistrée : " + String.join(", ", unknownNames));
             return REDIRECT_FEATURE_FLAGS;
         }
         FeatureFlag featureFlag = featureFlagService.getFeatureFlag(key);

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOFeatureFlagsController.java
@@ -1,11 +1,13 @@
 package fr.gouv.bo.controller;
 
+import fr.dossierfacile.common.constants.PartnerConstants;
 import fr.dossierfacile.common.entity.FeatureFlag;
 import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.common.service.interfaces.LotteryDrawService;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
 import fr.gouv.bo.service.TenantService;
+import fr.gouv.bo.service.UserApiService;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -31,11 +33,21 @@ public class BOFeatureFlagsController {
      * Global on/off flags, read through FeatureFlagService.isFeatureEnabled: rollout_pct and
      * only_for_new_user are ignored, so the rollout edition is hidden and refused for them.
      */
-    private static final Set<String> GLOBAL_FLAG_KEYS = Set.of(LotteryTicketService.TENANT_LOTTERY_FEATURE_FLAG);
+    private static final Set<String> GLOBAL_FLAG_KEYS = Set.of(
+            LotteryTicketService.TENANT_LOTTERY_FEATURE_FLAG,
+            OperatorReviewPolicy.PARTNER_COMPLETED_OPTIN_FEATURE_FLAG);
+
+    /**
+     * Partner-scoped flags: the opted-in partner list (user_api.name) is editable.
+     * TODO(partner-completed-optin-100): remove with the partner_completed_optin flag (this set, the
+     * "partners" model attribute, updateOptedInPartners and the modal in feature-flags.html).
+     */
+    private static final Set<String> PARTNER_SCOPED_FLAG_KEYS = Set.of(OperatorReviewPolicy.PARTNER_COMPLETED_OPTIN_FEATURE_FLAG);
 
     private final FeatureFlagService featureFlagService;
     private final TenantService tenantService;
     private final LotteryDrawService lotteryDrawService;
+    private final UserApiService userApiService;
 
     @GetMapping("/bo/feature-flags")
     public String featureFlags(Model model) {
@@ -50,7 +62,39 @@ public class BOFeatureFlagsController {
                 .orElse(false);
         model.addAttribute("completedRollbackAllowed", completedRollbackAllowed);
         model.addAttribute("globalFlagKeys", GLOBAL_FLAG_KEYS);
+        model.addAttribute("partnerScopedFlagKeys", PARTNER_SCOPED_FLAG_KEYS);
+        model.addAttribute("partners", userApiService.findAll());
         return "bo/feature-flags";
+    }
+
+    @PostMapping("/bo/feature-flags/opted-in-partners")
+    public String updateOptedInPartners(@RequestParam("key") String key, @RequestParam("value") String value,
+                                        RedirectAttributes redirectAttributes) {
+        if (!PARTNER_SCOPED_FLAG_KEYS.contains(key)) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                    "Le flag " + key + " n'est pas un flag partenaire : il n'a pas de liste de partenaires.");
+            return REDIRECT_FEATURE_FLAGS;
+        }
+        Set<String> names = FeatureFlag.builder().optedInPartners(value).build().getOptedInPartnerNames();
+        if (names.contains(PartnerConstants.DF_OWNER_NAME)) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                    "Le partenaire " + PartnerConstants.DF_OWNER_NAME + " (espace propriétaire) ne peut pas intégrer le statut COMPLETED.");
+            return REDIRECT_FEATURE_FLAGS;
+        }
+        // Every name must be an existing partner (user_api.name): nothing is saved otherwise
+        List<String> unknownNames = names.stream()
+                .filter(name -> userApiService.findByName(name).isEmpty())
+                .toList();
+        if (!unknownNames.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                    "Client id(s) inconnu(s), liste non enregistrée : " + String.join(", ", unknownNames));
+            return REDIRECT_FEATURE_FLAGS;
+        }
+        FeatureFlag featureFlag = featureFlagService.getFeatureFlag(key);
+        featureFlagService.updateOptedInPartners(featureFlag, names);
+        redirectAttributes.addFlashAttribute("successMessage",
+                "Partenaires ayant intégré le statut COMPLETED (flag " + key + ") : " + (names.isEmpty() ? "aucun" : String.join(", ", names)));
+        return REDIRECT_FEATURE_FLAGS;
     }
 
     @PostMapping("/bo/feature-flags/toggle")

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/controller/BOTenantController.java
@@ -115,9 +115,7 @@ public class BOTenantController {
         Tenant tenant = requireTenant(id);
 
         UserApi userApi = userApiService.findById(partnerDTO.getPartner());
-        PartnerCallBackType partnerCallBackType = tenant.getStatus() == TenantFileStatus.VALIDATED ?
-                PartnerCallBackType.VERIFIED_ACCOUNT :
-                PartnerCallBackType.CREATED_ACCOUNT;
+        PartnerCallBackType partnerCallBackType = PartnerCallBackType.forTenantStatus(tenant.getStatus());
         ApplicationModel webhookDTO = partnerCallBackService.getWebhookDTO(tenant, userApi, partnerCallBackType);
         partnerCallBackService.sendCallBack(tenant, userApi, webhookDTO);
 

--- a/dossierfacile-bo/src/main/java/fr/gouv/bo/service/UserApiService.java
+++ b/dossierfacile-bo/src/main/java/fr/gouv/bo/service/UserApiService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -33,6 +34,10 @@ public class UserApiService {
 
     public List<UserApi> findPartnersLinkedToTenant(Long id) {
         return userApiRepository.findPartnersLinkedToTenant(id);
+    }
+
+    public Optional<UserApi> findByName(String name) {
+        return userApiRepository.findByName(name);
     }
 
     public List<UserApi> findAll() {

--- a/dossierfacile-bo/src/main/resources/templates/bo/feature-flags.html
+++ b/dossierfacile-bo/src/main/resources/templates/bo/feature-flags.html
@@ -11,6 +11,7 @@
     <div class="container-lg">
         <h1 class="margin-bottom">Liste des features flags</h1>
         <div th:if="${errorMessage}" class="alert alert-danger" role="alert" th:text="${errorMessage}"></div>
+        <div th:if="${successMessage}" class="alert alert-success" role="alert" th:text="${successMessage}"></div>
         <div class="table-responsive">
             <table class="table table-striped table-bordered table-hover">
                 <thead>
@@ -25,9 +26,17 @@
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="feature : ${featureFlags}" th:with="isGlobal=${globalFlagKeys.contains(feature.key)}">
+                <tr th:each="feature : ${featureFlags}" th:with="isGlobal=${globalFlagKeys.contains(feature.key)},isPartnerScoped=${partnerScopedFlagKeys.contains(feature.key)}">
                     <td th:text="${feature.key}" class="align-middle"></td>
-                    <td th:text="${feature.description}" class="align-middle"></td>
+                    <td class="align-middle">
+                        <span th:text="${feature.description}"></span>
+                        <!-- Partner-scoped flags: the opted-in partners (user_api.name) -->
+                        <div th:if="${isPartnerScoped}" class="mt-2">
+                            <span class="text-muted small">Partenaires ayant intégré COMPLETED :</span>
+                            <span th:if="${#sets.isEmpty(feature.optedInPartnerNames)}" class="badge bg-secondary">aucun</span>
+                            <span th:each="partnerName : ${feature.optedInPartnerNames}" th:text="${partnerName}" class="badge bg-primary"></span>
+                        </div>
+                    </td>
                     <td th:text="${#temporals.format(feature.deploymentDate, 'dd/MM/yyyy HH:mm')}" class="align-middle"></td>
                     <!-- Global on/off flags ignore only_for_new_user and rollout_pct: show it instead of misleading values -->
                     <td th:if="${isGlobal}" class="text-center align-middle">
@@ -59,6 +68,56 @@
                                     <span class="fa fa-toggle-off"></span> Start
                                 </button>
                             </form>
+
+                            <!-- Edit opted-in partners (Triggers Modal) — partner-scoped flags only -->
+                            <button th:if="${isPartnerScoped}" type="button" class="btn btn-sm btn-primary text-nowrap" data-bs-toggle="modal" th:data-bs-target="'#partnersModal-' + ${feature.key}">
+                                <span class="fa fa-handshake-o"></span> Partenaires
+                            </button>
+
+                            <!-- Modal for Editing the opted-in partners -->
+                            <div th:if="${isPartnerScoped}" class="modal fade" th:id="'partnersModal-' + ${feature.key}" tabindex="-1" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <form th:action="@{/bo/feature-flags/opted-in-partners}" method="post">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" th:text="'Partenaires ayant intégré le statut COMPLETED - ' + ${feature.key}">Partenaires ayant intégré le statut COMPLETED</h5>
+                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                            </div>
+                                            <div class="modal-body text-start">
+                                                <div class="alert alert-warning" role="alert">
+                                                    <i class="fa fa-exclamation-triangle"></i>
+                                                    <strong>Attention :</strong> un partenaire listé ici verra le statut <strong>COMPLETED</strong>
+                                                    et recevra le webhook <strong>COMPLETED_ACCOUNT</strong>. Ne l'ajouter qu'après recette de son intégration.
+                                                    Le retirer n'agit que sur les nouvelles soumissions et liaisons.
+                                                </div>
+                                                <div class="mb-3">
+                                                    <label th:for="'partnersValue-' + ${feature.key}" class="form-label">
+                                                        Client ids Keycloak des partenaires (<code>dfconnect-xxx</code>, champ « clientId » de la fiche partenaire), séparés par des virgules
+                                                    </label>
+                                                    <textarea class="form-control" rows="3" th:id="'partnersValue-' + ${feature.key}" name="value"
+                                                              th:text="${feature.optedInPartners}"></textarea>
+                                                    <div class="form-text">
+                                                        Liste vide = aucun partenaire. <code th:text="${T(fr.dossierfacile.common.constants.PartnerConstants).DF_OWNER_NAME}"></code> est interdit.
+                                                    </div>
+                                                </div>
+                                                <details>
+                                                    <summary class="small text-muted">Client ids des partenaires connus</summary>
+                                                    <ul class="small mb-0">
+                                                        <li th:each="partner : ${partners}" th:unless="${partner.disabled}">
+                                                            <code th:text="${partner.name}"></code> — <span th:text="${partner.name2}"></span>
+                                                        </li>
+                                                    </ul>
+                                                </details>
+                                                <input type="hidden" name="key" th:value="${feature.key}"/>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                                                <button type="submit" class="btn btn-primary">Valider</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
 
                             <!-- Edit Rollout Button (Triggers Modal) — not for global on/off flags -->
                             <button th:unless="${isGlobal}" type="button" class="btn btn-sm btn-primary" data-bs-toggle="modal" th:data-bs-target="'#rolloutModal-' + ${feature.key}">

--- a/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOFeatureFlagsControllerTest.java
+++ b/dossierfacile-bo/src/test/java/fr/gouv/bo/controller/BOFeatureFlagsControllerTest.java
@@ -1,0 +1,90 @@
+package fr.gouv.bo.controller;
+
+import fr.dossierfacile.common.entity.FeatureFlag;
+import fr.dossierfacile.common.entity.UserApi;
+import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
+import fr.dossierfacile.common.service.interfaces.LotteryDrawService;
+import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
+import fr.gouv.bo.service.TenantService;
+import fr.gouv.bo.service.UserApiService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BOFeatureFlagsControllerTest {
+
+    private static final String KEY = OperatorReviewPolicy.PARTNER_COMPLETED_OPTIN_FEATURE_FLAG;
+
+    @Mock
+    private FeatureFlagService featureFlagService;
+    @Mock
+    private TenantService tenantService;
+    @Mock
+    private LotteryDrawService lotteryDrawService;
+    @Mock
+    private UserApiService userApiService;
+
+    private BOFeatureFlagsController controller;
+    private RedirectAttributesModelMap redirectAttributes;
+
+    @BeforeEach
+    void setUp() {
+        controller = new BOFeatureFlagsController(featureFlagService, tenantService, lotteryDrawService, userApiService);
+        redirectAttributes = new RedirectAttributesModelMap();
+    }
+
+    @Test
+    void updateOptedInPartners_savesKnownPartners() {
+        FeatureFlag flag = FeatureFlag.builder().key(KEY).build();
+        when(featureFlagService.getFeatureFlag(KEY)).thenReturn(flag);
+        when(userApiService.findByName(anyString())).thenReturn(Optional.of(new UserApi()));
+
+        String view = controller.updateOptedInPartners(KEY, " dfconnect-ics, other ", redirectAttributes);
+
+        assertThat(view).isEqualTo("redirect:/bo/feature-flags");
+        verify(featureFlagService).updateOptedInPartners(eq(flag), eq(Set.of("dfconnect-ics", "other")));
+        assertThat(redirectAttributes.getFlashAttributes()).containsKey("successMessage");
+    }
+
+    @Test
+    void updateOptedInPartners_refusesUnknownPartnerAndSavesNothing() {
+        when(userApiService.findByName("dfconnect-ics")).thenReturn(Optional.of(new UserApi()));
+        when(userApiService.findByName("typo")).thenReturn(Optional.empty());
+
+        controller.updateOptedInPartners(KEY, "dfconnect-ics,typo", redirectAttributes);
+
+        verify(featureFlagService, never()).updateOptedInPartners(any(), any());
+        assertThat(redirectAttributes.getFlashAttributes().get("errorMessage").toString()).contains("typo");
+    }
+
+    @Test
+    void updateOptedInPartners_refusesTheOwnerPartner() {
+        controller.updateOptedInPartners(KEY, "dfconnect-proprietaire", redirectAttributes);
+
+        verify(featureFlagService, never()).updateOptedInPartners(any(), any());
+        assertThat(redirectAttributes.getFlashAttributes()).containsKey("errorMessage");
+    }
+
+    @Test
+    void updateOptedInPartners_refusesNonPartnerScopedFlags() {
+        controller.updateOptedInPartners("tenant_completed_optin", "dfconnect-ics", redirectAttributes);
+
+        verify(featureFlagService, never()).updateOptedInPartners(any(), any());
+        assertThat(redirectAttributes.getFlashAttributes()).containsKey("errorMessage");
+    }
+}

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/FeatureFlag.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/entity/FeatureFlag.java
@@ -19,9 +19,13 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(name = "feature_flag")
@@ -57,6 +61,13 @@ public class FeatureFlag implements Serializable {
     @Column(name = "deployment_date")
     private LocalDateTime deploymentDate;
 
+    /**
+     * Partner-scoped flags: comma-separated list of {@code user_api.name} (Keycloak client
+     * ids) the flag applies to. Null or blank means no partner.
+     */
+    @Column(name = "opted_in_partners", columnDefinition = "TEXT")
+    private String optedInPartners;
+
     @Column(name = "created_at")
     @Builder.Default
     private LocalDateTime createdAt = LocalDateTime.now();
@@ -75,6 +86,29 @@ public class FeatureFlag implements Serializable {
     @OneToMany(mappedBy = "featureFlag", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @ToString.Exclude
     private Set<UserFeatureAssignmentHistory> assignmentHistory = new HashSet<>();
+
+    /**
+     * Partner names of {@link #optedInPartners}, trimmed, without blanks nor duplicates,
+     * in declaration order.
+     */
+    public Set<String> getOptedInPartnerNames() {
+        if (optedInPartners == null || optedInPartners.isBlank()) {
+            return new LinkedHashSet<>();
+        }
+        return Arrays.stream(optedInPartners.split(","))
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public static String joinPartnerNames(Collection<String> names) {
+        return names == null ? null : names.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
+                .distinct()
+                .collect(Collectors.joining(","));
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/PartnerCallBackType.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/PartnerCallBackType.java
@@ -1,5 +1,11 @@
 package fr.dossierfacile.common.enums;
 
+/**
+ * Webhook event types sent to partners. Status events are named after the status the
+ * dossier enters: CREATED_ACCOUNT (TO_PROCESS, in the operator queue),
+ * COMPLETED_ACCOUNT (COMPLETED),
+ * VERIFIED_ACCOUNT (VALIDATED), DENIED_ACCOUNT (DECLINED).
+ */
 public enum PartnerCallBackType {
     DELETED_ACCOUNT,
     VERIFIED_ACCOUNT,
@@ -9,5 +15,20 @@ public enum PartnerCallBackType {
     ARCHIVED_ACCOUNT,
     RETURNED_ACCOUNT,
     MERGED_ACCOUNT,
-    ACCESS_REVOKED
+    ACCESS_REVOKED,
+    COMPLETED_ACCOUNT;
+
+    /**
+     * Event describing the current status of a dossier, used when a partner is (re)sent
+     * the dossier as it stands: link to a partner, manual resend from the BO, scheduler.
+     */
+    public static PartnerCallBackType forTenantStatus(TenantFileStatus status) {
+        if (status == TenantFileStatus.VALIDATED) {
+            return VERIFIED_ACCOUNT;
+        }
+        if (status == TenantFileStatus.COMPLETED) {
+            return COMPLETED_ACCOUNT;
+        }
+        return CREATED_ACCOUNT;
+    }
 }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/TenantFileStatus.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/enums/TenantFileStatus.java
@@ -21,16 +21,7 @@ public enum TenantFileStatus {
     }
 
     /**
-     * A dossier can be shared by link or mail once complete and submitted:
-     * either verified by an operator (VALIDATED) or completed without
-     * operator verification (COMPLETED).
-     */
-    public boolean isCompletedOrValidated() {
-        return this == VALIDATED || this == COMPLETED;
-    }
-
-    /**
-     * Complete dossier (all mandatory documents + honor declaration) on its way to
+     * Complete, submitted dossier (all mandatory documents + honor declaration) on its way to
      * verification: COMPLETED → TO_PROCESS → VALIDATED. Excludes INCOMPLETE, DECLINED, ARCHIVED.
      */
     public boolean isCompletedOrBetter() {

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/ApplicationFullMapper.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/ApplicationFullMapper.java
@@ -5,7 +5,6 @@ import fr.dossierfacile.common.entity.Document;
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.entity.UserApi;
 import fr.dossierfacile.common.enums.ApartmentSharingLinkType;
-import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.model.apartment_sharing.ApplicationModel;
 import fr.dossierfacile.common.model.apartment_sharing.DocumentModel;
 import fr.dossierfacile.common.model.apartment_sharing.GuarantorModel;
@@ -24,7 +23,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Mapper(componentModel = "spring")
-public abstract class ApplicationFullMapper implements ApartmentSharingMapper, MasksCompletedStatusForPartner {
+public abstract class ApplicationFullMapper extends MasksCompletedStatusForPartner implements ApartmentSharingMapper {
     protected static final String DOCUMENT_DIRECT_PATH = "api/document/resource";
     protected static final String DOCUMENT_LINK_PATH = "api/application/links";
     protected static final String DOSSIER_PDF_PATH = "api/application/fullPdf";
@@ -52,8 +51,9 @@ public abstract class ApplicationFullMapper implements ApartmentSharingMapper, M
         var tokenOpt = resolvePartnerToken(apartmentSharing, userApi);
         if (tokenOpt.isPresent()) {
             String token = tokenOpt.get();
-            // Only expose dossierPdfUrl / dossierUrl when the global application is validated
-            if (apartmentSharing.getStatus() == TenantFileStatus.VALIDATED) {
+            // Only expose dossierPdfUrl / dossierUrl once the global application is submitted
+            // (TO_PROCESS, COMPLETED or VALIDATED)
+            if (apartmentSharing.getStatus().isCompletedOrBetter()) {
                 model.setDossierPdfUrl(applicationBaseUrl + "/" + DOSSIER_PDF_PATH + "/" + token);
                 model.setDossierUrl(tenantBaseUrl + "/" + DOSSIER_PATH + "/" + token);
             }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/MasksCompletedStatusForPartner.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/MasksCompletedStatusForPartner.java
@@ -2,18 +2,32 @@ package fr.dossierfacile.common.mapper;
 
 import fr.dossierfacile.common.entity.UserApi;
 import fr.dossierfacile.common.enums.TenantFileStatus;
+import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import org.mapstruct.Context;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * MapStruct mixin for mappers serving both the tenant itself and partners:
- * implementing it makes every mapped {@link TenantFileStatus} field go through the
- * defensive COMPLETED masking when a partner context is present. The tenant's own
- * views (userApi == null) keep seeing the real status.
+ * Base class for the MapStruct mappers serving both the tenant itself and partners:
+ * extending it makes every mapped {@link TenantFileStatus} field go through the
+ * defensive COMPLETED masking when a partner context is present and the partner did not
+ * opt in to the COMPLETED status.
+ * <p>
+ * TODO(partner-completed-optin-100): once every partner has integrated the COMPLETED status, delete this
+ * class, the {@code toPartnerVisibleStatus} usages in ApplicationFullMapper and
+ * TenantMapper, and the {@code setOperatorReviewPolicy} calls in their tests.
  */
-public interface MasksCompletedStatusForPartner {
+public abstract class MasksCompletedStatusForPartner {
 
-    default TenantFileStatus toPartnerVisibleStatus(TenantFileStatus status, @Context UserApi userApi) {
-        if (userApi == null) {
+    protected OperatorReviewPolicy operatorReviewPolicy;
+
+    @Autowired
+    public void setOperatorReviewPolicy(OperatorReviewPolicy operatorReviewPolicy) {
+        this.operatorReviewPolicy = operatorReviewPolicy;
+    }
+
+    public TenantFileStatus toPartnerVisibleStatus(TenantFileStatus status, @Context UserApi userApi) {
+        // Status checked first: the partner opt-in (a flag lookup) is only read for COMPLETED
+        if (userApi == null || status != TenantFileStatus.COMPLETED || operatorReviewPolicy.isPartnerOptedIn(userApi)) {
             return status;
         }
         return PartnerVisibleStatus.mask(status, getClass().getSimpleName());

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/PartnerVisibleStatus.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/mapper/PartnerVisibleStatus.java
@@ -4,13 +4,16 @@ import fr.dossierfacile.common.enums.TenantFileStatus;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Defensive safety net: the COMPLETED status must never reach a partner or owner
- * facing DTO (the automatic switch in registerTenant and the opt-in eligibility rules
- * are supposed to make this impossible). If the masking ever triggers, an invariant
- * is broken somewhere: the error log below is the alert to investigate.
+ * Defensive safety net: the COMPLETED status must never reach the DTOs served to a
+ * partner that did not opt in, nor to an owner (the automatic switch in registerTenant
+ * and the opt-in eligibility rules are supposed to make this impossible). If the masking
+ * ever triggers, an invariant is broken somewhere: the error log below is the alert to
+ * investigate.
  * <p>
- * TODO(completed-optin): once partners handle the COMPLETED status, remove this class
- * and its call sites in the partner and owner mappers (grep "PartnerVisibleStatus.mask").
+ * TODO(partner-completed-optin-100): once every partner has integrated the COMPLETED status, the partner
+ * masking ({@link MasksCompletedStatusForPartner}) goes away. The owner masking
+ * ({@link MasksCompletedStatusForOwner}) stays until the owner space handles COMPLETED,
+ * then this class can be deleted too (grep "PartnerVisibleStatus.mask").
  */
 @Slf4j
 public final class PartnerVisibleStatus {
@@ -20,7 +23,7 @@ public final class PartnerVisibleStatus {
 
     public static TenantFileStatus mask(TenantFileStatus status, String source) {
         if (status == TenantFileStatus.COMPLETED) {
-            log.error("Defensive status masking triggered in {}: a COMPLETED dossier should never be exposed to partners or owners", source);
+            log.error("Defensive status masking triggered in {}: a COMPLETED dossier should never be exposed to a partner that did not opt in, nor to an owner", source);
             return TenantFileStatus.TO_PROCESS;
         }
         return status;

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantCommonRepository.java
@@ -219,14 +219,14 @@ public interface TenantCommonRepository extends JpaRepository<Tenant, Long> {
     )
     List<Tenant> findAllDeclinedSinceXDaysAgo(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
 
-    // The full dossier PDF can only be generated for COMPLETED or VALIDATED dossiers whose documents
-    // (including guarantor ones) all have their watermarked file available
+    // The full dossier PDF can only be generated for submitted dossiers (TO_PROCESS, COMPLETED or
+    // VALIDATED) whose documents (including guarantor ones) all have their watermarked file available
     @Query(value = """
             SELECT COUNT(t.id)
             FROM tenant t
             WHERE t.apartment_sharing_id = :apartmentSharingId
               AND (
-                t.status NOT IN ('VALIDATED', 'COMPLETED')
+                t.status NOT IN ('VALIDATED', 'COMPLETED', 'TO_PROCESS')
                 OR EXISTS (
                     SELECT 1
                     FROM document d

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantUserApiRepository.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/repository/TenantUserApiRepository.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 public interface TenantUserApiRepository extends JpaRepository<TenantUserApi, TenantUserApiKey> {
     Optional<TenantUserApi> findFirstByTenantAndUserApi(Tenant tenant, UserApi userApi);
 
-    boolean existsByTenant(Tenant tenant);
 
     List<TenantUserApi> findAllByTenant(Tenant tenant);
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/CompletedDossierServiceImpl.java
@@ -10,7 +10,6 @@ import fr.dossierfacile.common.enums.QueueEntrySource;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
 import fr.dossierfacile.common.service.interfaces.MailCommonService;
@@ -35,7 +34,6 @@ public class CompletedDossierServiceImpl implements CompletedDossierService {
     private final TenantLogCommonService tenantLogCommonService;
     private final TenantMapperForMail tenantMapperForMail;
     private final Optional<MailCommonService> mailCommonService;
-    private final ApartmentSharingCommonService apartmentSharingCommonService;
     private final LotteryTicketService lotteryTicketService;
 
     // A COMPLETED dossier must never be exposed to partners: it goes back to the
@@ -54,9 +52,6 @@ public class CompletedDossierServiceImpl implements CompletedDossierService {
         tenantLogCommonService.logQueueEntered(tenant.getId(),
                 userApi != null ? QueueEntrySource.PARTNER_LINK : QueueEntrySource.COMPLETED_ROLLBACK);
         lotteryTicketService.cancelActiveTicket(tenant);
-        // The full PDF was rendered with the COMPLETED design: it must not
-        // survive the switch out of COMPLETED
-        apartmentSharingCommonService.resetDossierPdfGenerated(tenant.getApartmentSharing());
         if (userApi == null) {
             return;
         }

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/FeatureFlagServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/FeatureFlagServiceImpl.java
@@ -1,6 +1,8 @@
 package fr.dossierfacile.common.service;
 
+import fr.dossierfacile.common.constants.PartnerConstants;
 import fr.dossierfacile.common.entity.FeatureFlag;
+import fr.dossierfacile.common.entity.UserApi;
 import fr.dossierfacile.common.entity.UserFeatureAssignment;
 import fr.dossierfacile.common.entity.UserFeatureAssignmentHistory;
 import fr.dossierfacile.common.entity.UserFeatureAssignmentId;
@@ -14,6 +16,7 @@ import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.common.service.interfaces.UserFeatureAssignmentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 @Service
@@ -54,6 +59,39 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
     @Transactional(readOnly = true)
     public boolean isFeatureEnabled(String key) {
         return featureFlagRepository.findById(key).map(FeatureFlag::isActive).orElse(false);
+    }
+
+    // TODO(partner-completed-optin-100): the partner-scoped flag machinery (isPartnerOptedIn, updateOptedInPartners,
+    // FeatureFlag.optedInPartners, the BO modal) can be removed once every partner has
+    // integrated COMPLETED and the partner_completed_optin flag is dropped
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isPartnerOptedIn(String key, UserApi userApi) {
+        if (userApi == null || StringUtils.isBlank(userApi.getName())
+                || PartnerConstants.DF_OWNER_NAME.equals(userApi.getName())) {
+            return false;
+        }
+        var featureFlag = featureFlagRepository.findById(key);
+        if (featureFlag.isEmpty()) {
+            log.warn("Feature flag with key {} not found", key);
+            return false;
+        }
+        // Exact match after trim: the name is the Keycloak client id, case-sensitive
+        return featureFlag.get().isActive()
+                && featureFlag.get().getOptedInPartnerNames().contains(userApi.getName().trim());
+    }
+
+    @Override
+    @Transactional
+    public void updateOptedInPartners(FeatureFlag featureFlag, Collection<String> partnerNames) {
+        String newValue = FeatureFlag.joinPartnerNames(partnerNames);
+        if (newValue != null && Arrays.asList(newValue.split(",")).contains(PartnerConstants.DF_OWNER_NAME)) {
+            throw new IllegalArgumentException("The owner partner " + PartnerConstants.DF_OWNER_NAME + " cannot opt in");
+        }
+        log.info("Feature flag {}: opted-in partners changed from [{}] to [{}]",
+                featureFlag.getKey(), featureFlag.getOptedInPartners(), newValue);
+        featureFlag.setOptedInPartners(newValue);
+        featureFlagRepository.save(featureFlag);
     }
 
     private boolean checkAndAssign(Long userId, FeatureFlag featureFlag) {

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/LotteryDrawServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/LotteryDrawServiceImpl.java
@@ -16,7 +16,6 @@ import fr.dossierfacile.common.repository.LotteryDrawRepository;
 import fr.dossierfacile.common.repository.ProcessingCapacityRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.repository.TenantLogRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.common.service.interfaces.LotteryDrawService;
@@ -61,7 +60,6 @@ public class LotteryDrawServiceImpl implements LotteryDrawService {
     private final TenantLogRepository tenantLogRepository;
     private final TenantCommonRepository tenantCommonRepository;
     private final TenantLogCommonService tenantLogCommonService;
-    private final ApartmentSharingCommonService apartmentSharingCommonService;
     private final TenantMapperForMail tenantMapperForMail;
     private final Optional<MailCommonService> mailCommonService;
 
@@ -278,9 +276,6 @@ public class LotteryDrawServiceImpl implements LotteryDrawService {
         tenantLogCommonService.saveTenantLog(new TenantLog(LogType.LOTTERY_DRAWN, tenant.getId()));
         // Ticket already DRAWN: logged with bypass=false
         tenantLogCommonService.logQueueEntered(tenant.getId(), QueueEntrySource.LOTTERY_DRAW);
-        // The full PDF was rendered with the COMPLETED design: it must not
-        // survive the switch out of COMPLETED
-        apartmentSharingCommonService.resetDossierPdfGenerated(tenant.getApartmentSharing());
         return true;
     }
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/OperatorReviewPolicyImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/OperatorReviewPolicyImpl.java
@@ -2,6 +2,7 @@ package fr.dossierfacile.common.service;
 
 import fr.dossierfacile.common.entity.ApartmentSharing;
 import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.entity.UserApi;
 import fr.dossierfacile.common.enums.ApplicationType;
 import fr.dossierfacile.common.enums.LotteryTicketStatus;
 import fr.dossierfacile.common.enums.TenantFileStatus;
@@ -32,9 +33,13 @@ public class OperatorReviewPolicyImpl implements OperatorReviewPolicy {
         if (apartmentSharing == null || !ApplicationType.ALONE.equals(apartmentSharing.getApplicationType())) {
             return false;
         }
-        // Strict rule: any partner link (DFC or owner), even a dangling one, disables the opt-in
-        // TODO(completed-optin): relax this rule once partners handle the COMPLETED status
-        if (tenantUserApiRepository.existsByTenant(tenant)) {
+        // Every linked partner (DFC or owner), even a dangling link, must have opted in to the
+        // COMPLETED status: a single partner that did not opt in forces the operator queue
+        // TODO(partner-completed-optin-100): drop this rule once every partner has integrated COMPLETED
+        // (keep a check on the owner partner as long as the owner space is excluded)
+        boolean everyLinkedPartnerOptedIn = tenantUserApiRepository.findAllByTenant(tenant).stream()
+                .allMatch(link -> isPartnerOptedIn(link.getUserApi()));
+        if (!everyLinkedPartnerOptedIn) {
             return false;
         }
         // The feature flag check comes last: its first evaluation persists a bucket
@@ -42,6 +47,12 @@ public class OperatorReviewPolicyImpl implements OperatorReviewPolicy {
         // TODO(completed-optin-rollout-100): remove this check (and the flag) once the rollout
         //  is stable at 100%.
         return featureFlagService.isFeatureEnabledForUser(tenant.getId(), COMPLETED_OPTIN_FEATURE_FLAG);
+    }
+
+    // TODO(partner-completed-optin-100): remove with the partner_completed_optin flag once every partner has integrated COMPLETED
+    @Override
+    public boolean isPartnerOptedIn(UserApi userApi) {
+        return featureFlagService.isPartnerOptedIn(PARTNER_COMPLETED_OPTIN_FEATURE_FLAG, userApi);
     }
 
     @Override

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/PartnerCallBackServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/PartnerCallBackServiceImpl.java
@@ -12,6 +12,7 @@ import fr.dossierfacile.common.repository.ApartmentSharingRepository;
 import fr.dossierfacile.common.repository.CallbackLogRepository;
 import fr.dossierfacile.common.repository.TenantUserApiRepository;
 import fr.dossierfacile.common.service.interfaces.CompletedDossierService;
+import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import fr.dossierfacile.common.service.interfaces.RequestService;
 import fr.dossierfacile.common.utils.TransactionalUtil;
@@ -45,6 +46,7 @@ public class PartnerCallBackServiceImpl implements PartnerCallBackService {
     private final ApartmentSharingLinkRepository apartmentSharingLinkRepository;
     private final ObjectMapper objectMapper;
     private final CompletedDossierService completedDossierService;
+    private final OperatorReviewPolicy operatorReviewPolicy;
 
     public void registerTenant(Tenant tenant, UserApi userApi) {
         Optional<TenantUserApi> optionalTenantUserApi = tenantUserApiRepository.findFirstByTenantAndUserApi(tenant, userApi);
@@ -53,10 +55,14 @@ public class PartnerCallBackServiceImpl implements PartnerCallBackService {
                 return;
             }
 
-            // A COMPLETED dossier must never be exposed to partners: linking one (DFC or
-            // owner) sends it back to the operator queue before any callback is emitted
-            // TODO(completed-optin): remove this switch once partners handle the COMPLETED status
-            completedDossierService.switchBackToProcessing(tenant, userApi);
+            // A COMPLETED dossier must never be exposed to a partner that did not opt in:
+            // linking one (DFC or owner) sends it back to the operator queue before any
+            // callback is emitted. An opted-in partner sees the COMPLETED status instead.
+            // TODO(partner-completed-optin-100): remove this switch once every partner has integrated COMPLETED
+            // (the owner link still needs it as long as the owner space is excluded)
+            if (!operatorReviewPolicy.isPartnerOptedIn(userApi)) {
+                completedDossierService.switchBackToProcessing(tenant, userApi);
+            }
             ApartmentSharing apartmentSharing = tenant.getApartmentSharing();
             createPartnerLinksIfNeeded(tenant, userApi, apartmentSharing);
             sendCallbackIfEligible(tenant, userApi);
@@ -104,12 +110,9 @@ public class PartnerCallBackServiceImpl implements PartnerCallBackService {
     }
 
     private void sendCallbackIfEligible(Tenant tenant, UserApi userApi) {
-        if (userApi.getUrlCallback() != null && (
-                tenant.getStatus() == TenantFileStatus.VALIDATED
-                        || tenant.getStatus() == TenantFileStatus.TO_PROCESS)) {
-            PartnerCallBackType partnerCallBackType = tenant.getStatus() == TenantFileStatus.VALIDATED ?
-                    PartnerCallBackType.VERIFIED_ACCOUNT :
-                    PartnerCallBackType.CREATED_ACCOUNT;
+        // Submitted dossiers only (TO_PROCESS, COMPLETED, VALIDATED);
+        if (userApi.getUrlCallback() != null && tenant.getStatus() != null && tenant.getStatus().isCompletedOrBetter()) {
+            PartnerCallBackType partnerCallBackType = PartnerCallBackType.forTenantStatus(tenant.getStatus());
             ApplicationModel webhookDTO = getWebhookDTO(tenant, userApi, partnerCallBackType);
             sendCallBack(tenant, userApi, webhookDTO);
         }
@@ -210,6 +213,14 @@ public class PartnerCallBackServiceImpl implements PartnerCallBackService {
     public ApplicationModel getWebhookDTO(Tenant tenant, UserApi userApi, PartnerCallBackType partnerCallBackType) {
         ApartmentSharing apartmentSharing = tenant.getApartmentSharing();
         ApplicationModel applicationModel = applicationFullMapper.toApplicationModel(apartmentSharing, userApi);
+        // TODO(partner-completed-optin-100): remove this defensive downgrade once every partner has integrated COMPLETED
+        if (partnerCallBackType == PartnerCallBackType.COMPLETED_ACCOUNT && !operatorReviewPolicy.isPartnerOptedIn(userApi)) {
+            // Same invariant as the status masking in the mappers: a partner that did not
+            // opt in must never learn about COMPLETED. Should not happen (the dossier would
+            // not be COMPLETED); if it does, investigate
+            log.error("Defensive callback type downgrade for partner {}: COMPLETED_ACCOUNT sent as CREATED_ACCOUNT", userApi.getName());
+            partnerCallBackType = PartnerCallBackType.CREATED_ACCOUNT;
+        }
         applicationModel.setPartnerCallBackType(partnerCallBackType);
         applicationModel.setOnTenantId(tenant.getId());
         return applicationModel;

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/TenantCommonServiceImpl.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/TenantCommonServiceImpl.java
@@ -86,6 +86,9 @@ public class TenantCommonServiceImpl implements TenantCommonService {
     public void changeTenantStatusToValidated(Tenant tenant) {
         tenant.setStatus(TenantFileStatus.VALIDATED);
         tenantCommonRepository.save(tenant);
+        // A full PDF rendered while the dossier was not verified (TO_PROCESS or COMPLETED
+        // design) must not survive the validation: it is regenerated lazily with the verified design
+        apartmentSharingCommonService.resetDossierPdfGenerated(tenant.getApartmentSharing());
         // the lottery draw win is spent
         lotteryTicketService.consumeDrawnTicket(tenant.getId());
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/FeatureFlagService.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/FeatureFlagService.java
@@ -1,13 +1,28 @@
 package fr.dossierfacile.common.service.interfaces;
 
 import fr.dossierfacile.common.entity.FeatureFlag;
+import fr.dossierfacile.common.entity.UserApi;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FeatureFlagService {
     boolean isFeatureEnabledForUser(Long userId, String key);
     boolean isFeatureEnabledForUser(Long userId, FeatureFlag featureFlag);
     boolean isFeatureEnabled(String key);
+
+    /**
+     * Partner-scoped flag: active and the partner's name is listed in its opted-in partners.
+     * The owner partner ({@code dfconnect-proprietaire}) is never opted in.
+     */
+    boolean isPartnerOptedIn(String key, UserApi userApi);
+
+    /**
+     * Replaces the opted-in partner list (names are trimmed and deduplicated).
+     *
+     * @throws IllegalArgumentException when the owner partner is listed
+     */
+    void updateOptedInPartners(FeatureFlag featureFlag, Collection<String> partnerNames);
 
     List<FeatureFlag> getAllFeatureFlags();
 

--- a/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/OperatorReviewPolicy.java
+++ b/dossierfacile-common-library/src/main/java/fr/dossierfacile/common/service/interfaces/OperatorReviewPolicy.java
@@ -1,6 +1,7 @@
 package fr.dossierfacile.common.service.interfaces;
 
 import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.entity.UserApi;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 
 /**
@@ -10,12 +11,29 @@ import fr.dossierfacile.common.enums.TenantFileStatus;
 public interface OperatorReviewPolicy {
 
     String COMPLETED_OPTIN_FEATURE_FLAG = "tenant_completed_optin";
+    /**
+     * Global flag whose {@code opted_in_partners} lists the partners (user_api.name) that
+     * accept the COMPLETED status. Not opted in: every other partner, or all of them when
+     * the flag is inactive.
+     * <p>
+     * TODO(partner-completed-optin-100): drop the flag (and every {@code isPartnerOptedIn} call site) once every
+     * partner has integrated COMPLETED.
+     */
+    String PARTNER_COMPLETED_OPTIN_FEATURE_FLAG = "partner_completed_optin";
 
     /**
-     * Scope: the COMPLETED status exists for this dossier (ALONE, no partner link, in the
-     * opt-in rollout).
+     * Scope: the COMPLETED status exists for this dossier (ALONE, every linked partner
+     * opted in, in the opt-in rollout).
      */
     boolean supportsCompletedStatus(Tenant tenant);
+
+    /**
+     * The partner accepts the COMPLETED status: it is listed in the active
+     * {@link #PARTNER_COMPLETED_OPTIN_FEATURE_FLAG} flag. Such a partner sees COMPLETED in
+     * its payloads, receives the COMPLETED_ACCOUNT webhook and does not send a COMPLETED
+     * dossier back to the operator queue when linked. The owner partner is never opted in.
+     */
+    boolean isPartnerOptedIn(UserApi userApi);
 
     /**
      * The "request an operator review" choice is available: dossier

--- a/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
+++ b/dossierfacile-common-library/src/main/resources/db/changelog/databaseChangeLog.xml
@@ -207,4 +207,5 @@
     <include file="db/migration/20260806000000-add-completed-optin.xml"/>
     <include file="db/migration/202608270000-add-document-ia-professional-analysis-flag.xml"/>
     <include file="db/migration/20260901000000-add-tenant-lottery.xml"/>
+    <include file="db/migration/20260910000000-add-partner-completed-optin-flag.xml"/>
 </databaseChangeLog>

--- a/dossierfacile-common-library/src/main/resources/db/migration/20260910000000-add-partner-completed-optin-flag.xml
+++ b/dossierfacile-common-library/src/main/resources/db/migration/20260910000000-add-partner-completed-optin-flag.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <!-- Partner-scoped feature flags: a comma-separated list of user_api.name (Keycloak
+         client ids). Used by partner_completed_optin to open the COMPLETED status partner
+         by partner. Null or empty means no partner. -->
+    <changeSet id="20260910000000-1" author="dossierfacile">
+        <addColumn tableName="feature_flag">
+            <column name="opted_in_partners" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="feature_flag" columnName="opted_in_partners"/>
+        </rollback>
+    </changeSet>
+
+    <!-- Global on/off flag (rollout_pct and only_for_new_user are ignored): when active, the
+         partners listed in opted_in_partners see the COMPLETED status, receive the
+         COMPLETED_ACCOUNT webhook and no longer send a COMPLETED dossier back to the queue. -->
+    <changeSet id="20260910000000-2" author="dossierfacile">
+        <insert tableName="feature_flag">
+            <column name="key" value="partner_completed_optin"/>
+            <column name="description" value="Partners listed in opted_in_partners (user_api.name) accept the COMPLETED status: no switch back to TO_PROCESS on link, COMPLETED visible in their payloads, COMPLETED_ACCOUNT webhook"/>
+            <column name="active" valueBoolean="false"/>
+            <column name="only_for_new_user" valueBoolean="false"/>
+            <column name="rollout_pct" valueNumeric="100"/>
+        </insert>
+        <rollback>
+            <delete tableName="feature_flag">
+                <where>key = 'partner_completed_optin'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/FeatureFlagTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/entity/FeatureFlagTest.java
@@ -1,0 +1,31 @@
+package fr.dossierfacile.common.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeatureFlagTest {
+
+    @Test
+    void optedInPartnerNames_isEmptyForNullOrBlank() {
+        assertThat(FeatureFlag.builder().optedInPartners(null).build().getOptedInPartnerNames()).isEmpty();
+        assertThat(FeatureFlag.builder().optedInPartners("  ").build().getOptedInPartnerNames()).isEmpty();
+    }
+
+    @Test
+    void optedInPartnerNames_trimsSkipsBlanksAndDeduplicatesKeepingOrder() {
+        FeatureFlag flag = FeatureFlag.builder().optedInPartners(" b , a ,, b ,").build();
+
+        assertThat(flag.getOptedInPartnerNames()).containsExactly("b", "a");
+    }
+
+    @Test
+    void joinPartnerNames_normalizes() {
+        assertThat(FeatureFlag.joinPartnerNames(null)).isNull();
+        assertThat(FeatureFlag.joinPartnerNames(List.of())).isEmpty();
+        assertThat(FeatureFlag.joinPartnerNames(Arrays.asList(" a ", null, "b", "a", ""))).isEqualTo("a,b");
+    }
+}

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/enums/PartnerCallBackTypeTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/enums/PartnerCallBackTypeTest.java
@@ -1,0 +1,18 @@
+package fr.dossierfacile.common.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartnerCallBackTypeTest {
+
+    @Test
+    void forTenantStatus_namesTheEventAfterTheStatus() {
+        assertThat(PartnerCallBackType.forTenantStatus(TenantFileStatus.VALIDATED)).isEqualTo(PartnerCallBackType.VERIFIED_ACCOUNT);
+        assertThat(PartnerCallBackType.forTenantStatus(TenantFileStatus.COMPLETED)).isEqualTo(PartnerCallBackType.COMPLETED_ACCOUNT);
+        assertThat(PartnerCallBackType.forTenantStatus(TenantFileStatus.TO_PROCESS)).isEqualTo(PartnerCallBackType.CREATED_ACCOUNT);
+        // Historical behaviour of the manual resends for any other status
+        assertThat(PartnerCallBackType.forTenantStatus(TenantFileStatus.INCOMPLETE)).isEqualTo(PartnerCallBackType.CREATED_ACCOUNT);
+        assertThat(PartnerCallBackType.forTenantStatus(null)).isEqualTo(PartnerCallBackType.CREATED_ACCOUNT);
+    }
+}

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/mapper/ApplicationFullMapperTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/mapper/ApplicationFullMapperTest.java
@@ -147,6 +147,45 @@ class ApplicationFullMapperTest {
             assertThat(model.getDossierUrl()).isEqualTo("https://example.com/file/" + partnerToken);
         }
 
+        /*
+            A submitted but not yet verified dossier (TO_PROCESS) can be shared: the partner
+            gets dossierPdfUrl and dossierUrl as for a VALIDATED dossier.
+        */
+        @Test
+        void shouldExposeDossierUrlsForToProcessDossierWithPartnerLink() {
+            ApplicationFullMapperImpl mapper = new ApplicationFullMapperImpl();
+            mapper.applicationBaseUrl = "https://api.example.com";
+            mapper.tenantBaseUrl = "https://example.com";
+
+            Tenant tenant = Tenant.builder()
+                    .id(1L)
+                    .status(TenantFileStatus.TO_PROCESS)
+                    .documents(new ArrayList<>())
+                    .guarantors(new ArrayList<>())
+                    .build();
+
+            UUID partnerToken = UUID.randomUUID();
+            UserApi userApi = UserApi.builder().id(42L).build();
+
+            ApartmentSharing apartmentSharing = new ApartmentSharing();
+            apartmentSharing.setTenants(List.of(tenant));
+            apartmentSharing.setApartmentSharingLinks(List.of(
+                    ApartmentSharingLink.builder()
+                            .linkType(ApartmentSharingLinkType.PARTNER)
+                            .partnerId(42L)
+                            .fullData(true)
+                            .token(partnerToken)
+                            .build()
+            ));
+            tenant.setApartmentSharing(apartmentSharing);
+
+            ApplicationModel model = mapper.toApplicationModel(apartmentSharing, userApi);
+
+            assertThat(model.getStatus()).isEqualTo(TenantFileStatus.TO_PROCESS);
+            assertThat(model.getDossierPdfUrl()).isEqualTo("https://api.example.com/api/application/fullPdf/" + partnerToken);
+            assertThat(model.getDossierUrl()).isEqualTo("https://example.com/file/" + partnerToken);
+        }
+
         /* 
             When the tenant is not validated and userApi is not null,
             document url must follow link path format, but token, dossierPdfUrl and dossierUrl must be null.
@@ -356,11 +395,27 @@ class ApplicationFullMapperTest {
     @Nested
     class CompletedStatusMasking {
 
+        private final fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy operatorReviewPolicy =
+                org.mockito.Mockito.mock(fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy.class);
+
         private ApplicationFullMapperImpl buildMapper() {
             ApplicationFullMapperImpl mapper = new ApplicationFullMapperImpl();
             mapper.applicationBaseUrl = "https://api.example.com";
             mapper.tenantBaseUrl = "https://example.com";
+            mapper.setOperatorReviewPolicy(operatorReviewPolicy);
             return mapper;
+        }
+
+        // An opted-in partner sees the real COMPLETED status (webhooks, api-partner)
+        @Test
+        void shouldKeepCompletedStatusWhenMappingForAnOptedInPartner() {
+            UserApi userApi = UserApi.builder().id(200L).name("partner").build();
+            org.mockito.Mockito.when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(true);
+
+            ApplicationModel model = buildMapper().toApplicationModel(completedApartmentSharing(), userApi);
+
+            assertThat(model.getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
+            assertThat(model.getTenants().getFirst().getStatus()).isEqualTo(TenantFileStatus.COMPLETED);
         }
 
         private ApartmentSharing completedApartmentSharing() {
@@ -377,8 +432,8 @@ class ApplicationFullMapperTest {
             return apartmentSharing;
         }
 
-        // The COMPLETED status must never reach a partner facing DTO (webhooks,
-        // api-partner): this test protects the defensive masking
+        // The COMPLETED status must never reach a DTO served to a partner that did not
+        // opt in (webhooks, api-partner): this test protects the defensive masking
         @Test
         void shouldMaskCompletedStatusWhenMappingForAPartner() {
             UserApi userApi = UserApi.builder().id(200L).name("partner").build();

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/CompletedDossierServiceImplTest.java
@@ -9,7 +9,6 @@ import fr.dossierfacile.common.enums.LogType;
 import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
 import fr.dossierfacile.common.service.interfaces.MailCommonService;
 import fr.dossierfacile.common.service.interfaces.TenantLogCommonService;
@@ -32,7 +31,6 @@ class CompletedDossierServiceImplTest {
     private TenantLogCommonService tenantLogCommonService;
     private TenantMapperForMail tenantMapperForMail;
     private MailCommonService mailCommonService;
-    private ApartmentSharingCommonService apartmentSharingCommonService;
     private LotteryTicketService lotteryTicketService;
 
     private CompletedDossierServiceImpl service;
@@ -46,7 +44,6 @@ class CompletedDossierServiceImplTest {
         tenantLogCommonService = mock(TenantLogCommonService.class);
         tenantMapperForMail = mock(TenantMapperForMail.class);
         mailCommonService = mock(MailCommonService.class);
-        apartmentSharingCommonService = mock(ApartmentSharingCommonService.class);
         lotteryTicketService = mock(LotteryTicketService.class);
 
         service = new CompletedDossierServiceImpl(
@@ -54,7 +51,6 @@ class CompletedDossierServiceImplTest {
                 tenantLogCommonService,
                 tenantMapperForMail,
                 Optional.of(mailCommonService),
-                apartmentSharingCommonService,
                 lotteryTicketService
         );
 
@@ -87,8 +83,6 @@ class CompletedDossierServiceImplTest {
                 verify(tenantCommonRepository).save(tenant);
                 verify(tenantLogCommonService).saveTenantLog(argThat(log ->
                         log.getLogType() == LogType.COMPLETED_SWITCHED_TO_PROCESS && log.getTenantId().equals(tenant.getId())));
-                // The full PDF rendered with the COMPLETED design is dropped
-                verify(apartmentSharingCommonService).resetDossierPdfGenerated(apartmentSharing);
 
                 // And - the mail mentioning the partner is sent after commit
                 verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
@@ -111,7 +105,6 @@ class CompletedDossierServiceImplTest {
             assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.TO_PROCESS);
             verify(tenantCommonRepository).save(tenant);
             verify(tenantLogCommonService).saveTenantLog(any(TenantLog.class));
-            verify(apartmentSharingCommonService).resetDossierPdfGenerated(apartmentSharing);
             verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
         }
 
@@ -124,7 +117,6 @@ class CompletedDossierServiceImplTest {
             assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.VALIDATED);
             verify(tenantCommonRepository, never()).save(any(Tenant.class));
             verify(tenantLogCommonService, never()).saveTenantLog(any(TenantLog.class));
-            verify(apartmentSharingCommonService, never()).resetDossierPdfGenerated(any());
             verify(mailCommonService, never()).sendEmailCompletedSwitchedToProcessing(any(), any());
         }
     }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/FeatureFlagServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/FeatureFlagServiceImplTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -368,6 +369,93 @@ class FeatureFlagServiceImplTest {
             assertThat(featureFlag.isActive()).isTrue();
             assertThat(featureFlag.getDeploymentDate()).isNotNull();
             verify(featureFlagRepository).save(featureFlag);
+        }
+    }
+
+    @Nested
+    class IsPartnerOptedIn {
+
+        private static final String KEY = "partner_completed_optin";
+
+        private UserApi partner(String name) {
+            return UserApi.builder().id(1L).name(name).build();
+        }
+
+        @Test
+        void should_return_false_when_partner_is_null_or_has_no_name() {
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, null)).isFalse();
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner(" "))).isFalse();
+            verifyNoInteractions(featureFlagRepository);
+        }
+
+        @Test
+        void should_return_false_when_flag_is_missing() {
+            when(featureFlagRepository.findById(KEY)).thenReturn(Optional.empty());
+
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("dfconnect-ics"))).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_flag_is_inactive_even_if_listed() {
+            when(featureFlagRepository.findById(KEY)).thenReturn(Optional.of(
+                    FeatureFlag.builder().key(KEY).active(false).optedInPartners("dfconnect-ics").build()));
+
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("dfconnect-ics"))).isFalse();
+        }
+
+        @Test
+        void should_return_true_only_for_listed_partners_when_active() {
+            when(featureFlagRepository.findById(KEY)).thenReturn(Optional.of(
+                    FeatureFlag.builder().key(KEY).active(true).optedInPartners(" dfconnect-ics , other-partner,").build()));
+
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("dfconnect-ics"))).isTrue();
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("other-partner "))).isTrue();
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("Dfconnect-Ics"))).isFalse();
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("unknown"))).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_list_is_empty() {
+            when(featureFlagRepository.findById(KEY)).thenReturn(Optional.of(
+                    FeatureFlag.builder().key(KEY).active(true).optedInPartners(null).build()));
+
+            assertThat(featureFlagService.isPartnerOptedIn(KEY, partner("dfconnect-ics"))).isFalse();
+        }
+    }
+
+    @Nested
+    class UpdateOptedInPartners {
+
+        @Test
+        void should_normalize_and_save_the_list() {
+            FeatureFlag featureFlag = FeatureFlag.builder().key("partner_completed_optin").optedInPartners("old").build();
+
+            featureFlagService.updateOptedInPartners(featureFlag, java.util.List.of(" a ", "b", "a", "", "c"));
+
+            assertThat(featureFlag.getOptedInPartners()).isEqualTo("a,b,c");
+            verify(featureFlagRepository).save(featureFlag);
+        }
+
+        @Test
+        void should_clear_the_list_when_empty() {
+            FeatureFlag featureFlag = FeatureFlag.builder().key("partner_completed_optin").optedInPartners("a").build();
+
+            featureFlagService.updateOptedInPartners(featureFlag, java.util.List.of());
+
+            assertThat(featureFlag.getOptedInPartners()).isEmpty();
+            assertThat(featureFlag.getOptedInPartnerNames()).isEmpty();
+            verify(featureFlagRepository).save(featureFlag);
+        }
+
+        @Test
+        void should_refuse_the_owner_partner() {
+            FeatureFlag featureFlag = FeatureFlag.builder().key("partner_completed_optin").optedInPartners("a").build();
+
+            assertThatThrownBy(() -> featureFlagService.updateOptedInPartners(featureFlag, java.util.List.of("a", "dfconnect-proprietaire")))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            assertThat(featureFlag.getOptedInPartners()).isEqualTo("a");
+            verify(featureFlagRepository, never()).save(any());
         }
     }
 }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/LotteryDrawServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/LotteryDrawServiceImplTest.java
@@ -16,7 +16,6 @@ import fr.dossierfacile.common.repository.ProcessingCapacityRepository;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.repository.TenantLogRepository;
 import fr.dossierfacile.common.repository.TenantUserApiRepository;
-import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
 import fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy;
 import fr.dossierfacile.common.service.interfaces.FeatureFlagService;
 import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
@@ -57,7 +56,6 @@ class LotteryDrawServiceImplTest {
     private TenantLogRepository tenantLogRepository;
     private TenantCommonRepository tenantCommonRepository;
     private TenantLogCommonService tenantLogCommonService;
-    private ApartmentSharingCommonService apartmentSharingCommonService;
     private TenantMapperForMail tenantMapperForMail;
     private MailCommonService mailCommonService;
 
@@ -74,7 +72,6 @@ class LotteryDrawServiceImplTest {
         tenantLogRepository = mock(TenantLogRepository.class);
         tenantCommonRepository = mock(TenantCommonRepository.class);
         tenantLogCommonService = mock(TenantLogCommonService.class);
-        apartmentSharingCommonService = mock(ApartmentSharingCommonService.class);
         tenantMapperForMail = mock(TenantMapperForMail.class);
         mailCommonService = mock(MailCommonService.class);
         lotteryTicketService = new LotteryTicketServiceImpl(
@@ -93,7 +90,6 @@ class LotteryDrawServiceImplTest {
                 tenantLogRepository,
                 tenantCommonRepository,
                 tenantLogCommonService,
-                apartmentSharingCommonService,
                 tenantMapperForMail,
                 Optional.of(mailCommonService)
         );
@@ -319,7 +315,10 @@ class LotteryDrawServiceImplTest {
             mockBypass(0);
             LotteryTicket ticket = pendingTicket(1L, 100L);
             Tenant tenant = tenant(100L, TenantFileStatus.COMPLETED);
-            listedThenChanged(List.of(ticket), () -> when(tenantUserApiRepository.existsByTenant(tenant)).thenReturn(true));
+            listedThenChanged(List.of(ticket), () -> when(tenantUserApiRepository.findAllByTenant(tenant)).thenReturn(List.of(
+                    fr.dossierfacile.common.entity.TenantUserApi.builder()
+                            .userApi(fr.dossierfacile.common.entity.UserApi.builder().id(9L).name("closed-partner").build())
+                            .build())));
 
             Optional<LotteryDraw> draw = service.executeDrawIfNeeded(DRAW_DATE);
 

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/OperatorReviewPolicyImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/OperatorReviewPolicyImplTest.java
@@ -56,8 +56,21 @@ class OperatorReviewPolicyImplTest {
         return buildTenant(TenantFileStatus.TO_PROCESS, ApplicationType.ALONE);
     }
 
+    private fr.dossierfacile.common.entity.TenantUserApi linkTo(String partnerName) {
+        return fr.dossierfacile.common.entity.TenantUserApi.builder()
+                .userApi(fr.dossierfacile.common.entity.UserApi.builder().id((long) partnerName.hashCode()).name(partnerName).build())
+                .build();
+    }
+
+    private void mockPartnerOptIn(String partnerName, boolean optedIn) {
+        when(featureFlagService.isPartnerOptedIn(
+                org.mockito.ArgumentMatchers.eq(OperatorReviewPolicy.PARTNER_COMPLETED_OPTIN_FEATURE_FLAG),
+                org.mockito.ArgumentMatchers.argThat(userApi -> userApi != null && partnerName.equals(userApi.getName()))))
+                .thenReturn(optedIn);
+    }
+
     private void mockNoPartner(Tenant tenant, boolean flagEnabled) {
-        when(tenantUserApiRepository.existsByTenant(tenant)).thenReturn(false);
+        when(tenantUserApiRepository.findAllByTenant(tenant)).thenReturn(java.util.List.of());
         when(featureFlagService.isFeatureEnabledForUser(tenant.getId(), OperatorReviewPolicy.COMPLETED_OPTIN_FEATURE_FLAG))
                 .thenReturn(flagEnabled);
     }
@@ -99,13 +112,39 @@ class OperatorReviewPolicyImplTest {
         }
 
         @Test
-        void should_not_support_when_linked_to_a_partner() {
+        void should_not_support_when_linked_to_a_partner_that_did_not_opt_in() {
             Tenant tenant = buildAloneTenant();
-            when(tenantUserApiRepository.existsByTenant(tenant)).thenReturn(true);
+            when(tenantUserApiRepository.findAllByTenant(tenant)).thenReturn(java.util.List.of(linkTo("closed-partner")));
+            mockPartnerOptIn("closed-partner", false);
 
             assertThat(operatorReviewPolicy.supportsCompletedStatus(tenant)).isFalse();
-            // The flag must not be checked (nor assign a bucket) for non-candidates
-            verifyNoInteractions(featureFlagService);
+            // The opt-in flag must not be checked (nor assign a bucket) for non-candidates
+            org.mockito.Mockito.verify(featureFlagService, org.mockito.Mockito.never())
+                    .isFeatureEnabledForUser(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyString());
+        }
+
+        @Test
+        void should_support_when_every_linked_partner_opted_in() {
+            Tenant tenant = buildAloneTenant();
+            when(tenantUserApiRepository.findAllByTenant(tenant)).thenReturn(java.util.List.of(linkTo("open-a"), linkTo("open-b")));
+            mockPartnerOptIn("open-a", true);
+            mockPartnerOptIn("open-b", true);
+            when(featureFlagService.isFeatureEnabledForUser(tenant.getId(), OperatorReviewPolicy.COMPLETED_OPTIN_FEATURE_FLAG))
+                    .thenReturn(true);
+
+            assertThat(operatorReviewPolicy.supportsCompletedStatus(tenant)).isTrue();
+        }
+
+        @Test
+        void should_not_support_when_one_linked_partner_did_not_opt_in() {
+            Tenant tenant = buildAloneTenant();
+            when(tenantUserApiRepository.findAllByTenant(tenant)).thenReturn(java.util.List.of(linkTo("open-a"), linkTo("closed-partner")));
+            mockPartnerOptIn("open-a", true);
+            mockPartnerOptIn("closed-partner", false);
+
+            assertThat(operatorReviewPolicy.supportsCompletedStatus(tenant)).isFalse();
+            org.mockito.Mockito.verify(featureFlagService, org.mockito.Mockito.never())
+                    .isFeatureEnabledForUser(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyString());
         }
 
         @Test
@@ -282,6 +321,18 @@ class OperatorReviewPolicyImplTest {
                 assertThat(operatorReviewPolicy.resolveStatus(tenant, TenantFileStatus.TO_PROCESS)).isEqualTo(TenantFileStatus.TO_PROCESS);
                 verifyNoInteractions(tenantUserApiRepository);
             }
+        }
+    }
+
+    @Nested
+    class IsPartnerOptedIn {
+
+        @Test
+        void should_delegate_to_the_partner_completed_optin_flag() {
+            fr.dossierfacile.common.entity.UserApi partner = fr.dossierfacile.common.entity.UserApi.builder().id(1L).name("dfconnect-ics").build();
+            when(featureFlagService.isPartnerOptedIn(OperatorReviewPolicy.PARTNER_COMPLETED_OPTIN_FEATURE_FLAG, partner)).thenReturn(true);
+
+            assertThat(operatorReviewPolicy.isPartnerOptedIn(partner)).isTrue();
         }
     }
 }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/PartnerCallBackServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/PartnerCallBackServiceImplTest.java
@@ -32,6 +32,7 @@ class PartnerCallBackServiceImplTest {
     private ApartmentSharingLinkRepository apartmentSharingLinkRepository;
     private ObjectMapper objectMapper;
     private CompletedDossierService completedDossierService;
+    private fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy operatorReviewPolicy;
 
     private PartnerCallBackServiceImpl service;
 
@@ -49,6 +50,7 @@ class PartnerCallBackServiceImplTest {
         apartmentSharingLinkRepository = mock(ApartmentSharingLinkRepository.class);
         objectMapper = new ObjectMapper();
         completedDossierService = mock(CompletedDossierService.class);
+        operatorReviewPolicy = mock(fr.dossierfacile.common.service.interfaces.OperatorReviewPolicy.class);
 
         service = new PartnerCallBackServiceImpl(
                 tenantUserApiRepository,
@@ -58,7 +60,8 @@ class PartnerCallBackServiceImplTest {
                 apartmentSharingRepository,
                 apartmentSharingLinkRepository,
                 objectMapper,
-                completedDossierService
+                completedDossierService,
+                operatorReviewPolicy
         );
 
         apartmentSharing = ApartmentSharing.builder()
@@ -170,8 +173,9 @@ class PartnerCallBackServiceImplTest {
     }
 
     @Test
-    void should_delegate_completed_switch_when_linking_tenant_to_partner() {
+    void should_delegate_completed_switch_when_linking_tenant_to_a_partner_that_did_not_opt_in() {
         // Given
+        when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(false);
         when(tenantUserApiRepository.findFirstByTenantAndUserApi(tenant, userApi))
                 .thenReturn(Optional.empty());
         when(apartmentSharingLinkRepository.findByApartmentSharingAndPartnerIdAndLinkTypeAndDeletedIsFalse(
@@ -188,6 +192,24 @@ class PartnerCallBackServiceImplTest {
     }
 
     @Test
+    void should_not_switch_when_linking_tenant_to_an_opted_in_partner() {
+        // Given
+        when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(true);
+        when(tenantUserApiRepository.findFirstByTenantAndUserApi(tenant, userApi))
+                .thenReturn(Optional.empty());
+        when(apartmentSharingLinkRepository.findByApartmentSharingAndPartnerIdAndLinkTypeAndDeletedIsFalse(
+                apartmentSharing, userApi.getId(), ApartmentSharingLinkType.PARTNER
+        )).thenReturn(Collections.emptyList());
+
+        // When
+        service.registerTenant(tenant, userApi);
+
+        // Then - the dossier keeps its status, the partner links are still created
+        verify(completedDossierService, never()).switchBackToProcessing(any(Tenant.class), any(UserApi.class));
+        verify(apartmentSharingLinkRepository, times(2)).save(any(ApartmentSharingLink.class));
+    }
+
+    @Test
     void should_not_switch_when_tenant_is_already_linked_to_partner() {
         // Given - the tenant_userapi link already exists
         when(tenantUserApiRepository.findFirstByTenantAndUserApi(tenant, userApi))
@@ -199,5 +221,41 @@ class PartnerCallBackServiceImplTest {
         // Then
         verify(completedDossierService, never()).switchBackToProcessing(any(Tenant.class), any(UserApi.class));
         verify(tenantUserApiRepository, never()).save(any(TenantUserApi.class));
+    }
+
+    @Test
+    void should_send_completed_account_when_linking_a_completed_dossier_to_an_opted_in_partner() {
+        // Given
+        tenant.setStatus(TenantFileStatus.COMPLETED);
+        userApi.setUrlCallback("https://partner.example/callback");
+        when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(true);
+        when(tenantUserApiRepository.findFirstByTenantAndUserApi(tenant, userApi)).thenReturn(Optional.empty());
+        when(apartmentSharingLinkRepository.findByApartmentSharingAndPartnerIdAndLinkTypeAndDeletedIsFalse(
+                apartmentSharing, userApi.getId(), ApartmentSharingLinkType.PARTNER)).thenReturn(Collections.emptyList());
+        when(applicationFullMapper.toApplicationModel(apartmentSharing, userApi))
+                .thenReturn(new fr.dossierfacile.common.model.apartment_sharing.ApplicationModel());
+
+        // When
+        service.registerTenant(tenant, userApi);
+
+        // Then
+        verify(completedDossierService, never()).switchBackToProcessing(any(Tenant.class), any(UserApi.class));
+        verify(requestService).send(
+                argThat(model -> model.getPartnerCallBackType() == fr.dossierfacile.common.enums.PartnerCallBackType.COMPLETED_ACCOUNT
+                        && model.getOnTenantId().equals(tenant.getId())),
+                eq("https://partner.example/callback"), any());
+    }
+
+    @Test
+    void should_downgrade_completed_account_for_a_partner_that_did_not_opt_in() {
+        tenant.setStatus(TenantFileStatus.COMPLETED);
+        when(operatorReviewPolicy.isPartnerOptedIn(userApi)).thenReturn(false);
+        when(applicationFullMapper.toApplicationModel(apartmentSharing, userApi))
+                .thenReturn(new fr.dossierfacile.common.model.apartment_sharing.ApplicationModel());
+
+        var model = service.getWebhookDTO(tenant, userApi, fr.dossierfacile.common.enums.PartnerCallBackType.COMPLETED_ACCOUNT);
+
+        org.assertj.core.api.Assertions.assertThat(model.getPartnerCallBackType())
+                .isEqualTo(fr.dossierfacile.common.enums.PartnerCallBackType.CREATED_ACCOUNT);
     }
 }

--- a/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/TenantCommonServiceImplTest.java
+++ b/dossierfacile-common-library/src/test/java/fr/dossierfacile/common/service/TenantCommonServiceImplTest.java
@@ -1,0 +1,91 @@
+package fr.dossierfacile.common.service;
+
+import fr.dossierfacile.common.dto.mail.ApartmentSharingDto;
+import fr.dossierfacile.common.dto.mail.TenantDto;
+import fr.dossierfacile.common.entity.ApartmentSharing;
+import fr.dossierfacile.common.entity.Tenant;
+import fr.dossierfacile.common.enums.ApplicationType;
+import fr.dossierfacile.common.enums.PartnerCallBackType;
+import fr.dossierfacile.common.enums.TenantFileStatus;
+import fr.dossierfacile.common.mapper.mail.ApartmentSharingMapperForMail;
+import fr.dossierfacile.common.mapper.mail.TenantMapperForMail;
+import fr.dossierfacile.common.repository.ApartmentSharingLinkRepository;
+import fr.dossierfacile.common.repository.ApartmentSharingRepository;
+import fr.dossierfacile.common.repository.DocumentCommonRepository;
+import fr.dossierfacile.common.repository.TenantCommonRepository;
+import fr.dossierfacile.common.service.interfaces.ApartmentSharingCommonService;
+import fr.dossierfacile.common.service.interfaces.LotteryTicketService;
+import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TenantCommonServiceImplTest {
+
+    private TenantCommonRepository tenantCommonRepository;
+    private PartnerCallBackService partnerCallBackService;
+    private ApartmentSharingCommonService apartmentSharingCommonService;
+    private LotteryTicketService lotteryTicketService;
+
+    private TenantCommonServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        tenantCommonRepository = mock(TenantCommonRepository.class);
+        partnerCallBackService = mock(PartnerCallBackService.class);
+        apartmentSharingCommonService = mock(ApartmentSharingCommonService.class);
+        lotteryTicketService = mock(LotteryTicketService.class);
+        TenantMapperForMail tenantMapperForMail = mock(TenantMapperForMail.class);
+        ApartmentSharingMapperForMail apartmentSharingMapperForMail = mock(ApartmentSharingMapperForMail.class);
+        when(tenantMapperForMail.toDto(any(Tenant.class))).thenReturn(new TenantDto());
+        when(apartmentSharingMapperForMail.toDto(any(ApartmentSharing.class))).thenReturn(new ApartmentSharingDto());
+
+        service = new TenantCommonServiceImpl(
+                mock(ApartmentSharingRepository.class),
+                mock(DocumentCommonRepository.class),
+                tenantCommonRepository,
+                mock(ApartmentSharingLinkRepository.class),
+                partnerCallBackService,
+                Optional.empty(),
+                tenantMapperForMail,
+                apartmentSharingMapperForMail,
+                apartmentSharingCommonService,
+                lotteryTicketService
+        );
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TransactionSynchronizationManager.clearSynchronization();
+    }
+
+    @Test
+    void changeTenantStatusToValidated_resetsTheFullPdfAndNotifiesPartners() {
+        Tenant tenant = Tenant.builder().id(1L).status(TenantFileStatus.TO_PROCESS).build();
+        ApartmentSharing apartmentSharing = new ApartmentSharing();
+        apartmentSharing.setApplicationType(ApplicationType.ALONE);
+        apartmentSharing.setTenants(new ArrayList<>(List.of(tenant)));
+        tenant.setApartmentSharing(apartmentSharing);
+
+        service.changeTenantStatusToValidated(tenant);
+
+        assertThat(tenant.getStatus()).isEqualTo(TenantFileStatus.VALIDATED);
+        verify(tenantCommonRepository).save(tenant);
+        // A full PDF rendered with the "not verified" design must not survive the validation
+        verify(apartmentSharingCommonService).resetDossierPdfGenerated(apartmentSharing);
+        verify(lotteryTicketService).consumeDrawnTicket(1L);
+        verify(partnerCallBackService).sendCallBack(tenant, PartnerCallBackType.VERIFIED_ACCOUNT);
+    }
+}

--- a/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplate.java
+++ b/dossierfacile-pdf-generator/src/main/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplate.java
@@ -287,7 +287,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
             PDPage pageTemplate = doc.getPage(0);
 
             if (hideHeaderLogos) {
-                // A COMPLETED (non verified) dossier must not carry the République
+                // A non verified dossier (TO_PROCESS or COMPLETED) must not carry the République
                 // Française and DossierFacile logos: cover the top band of the template
                 // before drawing the text headers
                 try (PDPageContentStream cover = new PDPageContentStream(doc, pageTemplate, PDPageContentStream.AppendMode.APPEND, true)) {
@@ -1238,8 +1238,8 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
     }
 
     // Fills the index pages (added by createFirstsPages) with the summary boxes and
-    // the clickable per-tenant document indexes. Not called for a COMPLETED dossier,
-    // which has no index pages.
+    // the clickable per-tenant document indexes. Not called for a non verified dossier
+    // (TO_PROCESS or COMPLETED), which has no index pages.
     private void fillIndexPages(PDDocument doc, ApartmentSharing apartmentSharing, List<Tenant> tenantList, List<Integer> indexPagesForDocuments) throws IOException {
         PDType0Font fontSpectralExtraBold = Fonts.SPECTRAL_EXTRA_BOLD.load(doc);
         PDType0Font fontMarianneRegular = Fonts.MARIANNE_REGULAR.load(doc);
@@ -1349,12 +1349,12 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
         pdDocumentOutline.addLast(pdOutlineItem);
         //endregion
 
-        // A COMPLETED (non verified) dossier renders without the index pages and
-        // without the RF/DossierFacile logos in the header of the pages (clarification
+        // A non verified dossier (TO_PROCESS or COMPLETED) renders without the index pages
+        // and without the RF/DossierFacile logos in the header of the pages (clarification
         // page included). A VALIDATED dossier keeps the historical rendering.
-        boolean completedDossier = apartmentSharing.getStatus() == TenantFileStatus.COMPLETED;
+        boolean unverifiedDossier = apartmentSharing.getStatus() != TenantFileStatus.VALIDATED;
 
-        if (completedDossier) {
+        if (unverifiedDossier) {
             // No index pages: the content starts at page 0
             indexPagesForDocuments.add(0);
         } else {
@@ -1366,10 +1366,10 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
                 .findFirst()
                 .orElseThrow(() -> new TenantNotFoundException(TenantType.CREATE));
 
-        addDocumentOfClarification(ut, tenantList, mainTenant, indexPagesForDocuments, pdOutlineItem, completedDossier);
+        addDocumentOfClarification(ut, tenantList, mainTenant, indexPagesForDocuments, pdOutlineItem, unverifiedDossier);
 
         //region Add files of documents to Dossier PDF
-        addFilesOfDocumentsToDossierPDF(ut, tenantList, indexPagesForDocuments, pdOutlineItem, completedDossier);
+        addFilesOfDocumentsToDossierPDF(ut, tenantList, indexPagesForDocuments, pdOutlineItem, unverifiedDossier);
         //endregion
 
         ByteArrayOutputStream merge = new ByteArrayOutputStream();
@@ -1391,7 +1391,7 @@ public class ApartmentSharingPdfDocumentTemplate implements PdfTemplate<Apartmen
 
             addPaginate(doc);
 
-            if (!completedDossier) {
+            if (!unverifiedDossier) {
                 fillIndexPages(doc, apartmentSharing, tenantList, indexPagesForDocuments);
             }
             doc.save(result);

--- a/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplateTest.java
+++ b/dossierfacile-pdf-generator/src/test/java/fr/dossierfacile/api/pdfgenerator/service/templates/ApartmentSharingPdfDocumentTemplateTest.java
@@ -56,12 +56,24 @@ public class ApartmentSharingPdfDocumentTemplateTest {
         }
     }
 
-    // A COMPLETED dossier renders with the dedicated first-page template
-    // (visual check: target/fullPdfGenerationCompleted.pdf)
+    // A non verified dossier (COMPLETED or TO_PROCESS) renders without index pages nor
+    // header logos (visual check: target/fullPdfGenerationCompleted.pdf / ...ToProcess.pdf)
     @Test
     void should_generate_pdf_for_completed_dossier(ApartmentSharing apartmentSharing) throws IOException {
         apartmentSharing.getTenants().forEach(tenant -> tenant.setStatus(TenantFileStatus.COMPLETED));
         File resultFile = new File("target/fullPdfGenerationCompleted.pdf");
+
+        try (FileOutputStream w = new FileOutputStream(resultFile); InputStream is = pdfService.render(apartmentSharing)) {
+            byte[] result = is.readAllBytes();
+            w.write(result);
+            Assertions.assertThat(result).isNotEmpty();
+        }
+    }
+
+    @Test
+    void should_generate_pdf_for_to_process_dossier(ApartmentSharing apartmentSharing) throws IOException {
+        apartmentSharing.getTenants().forEach(tenant -> tenant.setStatus(TenantFileStatus.TO_PROCESS));
+        File resultFile = new File("target/fullPdfGenerationToProcess.pdf");
 
         try (FileOutputStream w = new FileOutputStream(resultFile); InputStream is = pdfService.render(apartmentSharing)) {
             byte[] result = is.readAllBytes();

--- a/dossierfacile-task-scheduler/src/main/java/fr/dossierfacile/scheduler/tasks/document/PartnerCallbackService.java
+++ b/dossierfacile-task-scheduler/src/main/java/fr/dossierfacile/scheduler/tasks/document/PartnerCallbackService.java
@@ -2,7 +2,6 @@ package fr.dossierfacile.scheduler.tasks.document;
 
 import fr.dossierfacile.common.entity.Tenant;
 import fr.dossierfacile.common.enums.PartnerCallBackType;
-import fr.dossierfacile.common.enums.TenantFileStatus;
 import fr.dossierfacile.common.repository.TenantCommonRepository;
 import fr.dossierfacile.common.service.interfaces.PartnerCallBackService;
 import jakarta.transaction.Transactional;
@@ -24,9 +23,7 @@ public class PartnerCallbackService {
         log.debug("Send Callback to partners");
         Optional<Tenant> tenant = tenantCommonRepository.findById(tenantId);
         if (tenant.isPresent()) {
-            PartnerCallBackType partnerCallBackType = tenant.get().getStatus() == TenantFileStatus.VALIDATED ?
-                    PartnerCallBackType.VERIFIED_ACCOUNT :
-                    PartnerCallBackType.CREATED_ACCOUNT;
+            PartnerCallBackType partnerCallBackType = PartnerCallBackType.forTenantStatus(tenant.get().getStatus());
             partnerCallBackService.sendCallBack(tenant.get(), partnerCallBackType);
         }
     }


### PR DESCRIPTION
## Contexte

Cette PR ouvre `COMPLETED` **partenaire par partenaire** depuis le BO, et rend les dossiers `TO_PROCESS` partageables pour que `TO_PROCESS` et `COMPLETED` soient équivalents côté partenaire. 

## Changements

### 1. Partage en TO_PROCESS
- Liens, lien par défaut et full PDF ouverts à tout dossier TO_PROCESS

### 2. Flag `partner_completed_optin`
- Migration : colonne `feature_flag.opted_in_partners` (client ids `dfconnect-xxx`) + flag global inactif. Aucune autre table touchée.
- BO `/bo/feature-flags` : modale « Partenaires » (client ids validés contre `user_api`, propriétaire refusé).

### 3. Webhook `COMPLETED_ACCOUNT`
- Émis à la soumission en `COMPLETED`, à tous les partenaires liés. Rien sur `COMPLETED ↔ TO_PROCESS`.
